### PR TITLE
feat: liveklass-common 공통 예외 클래스 추가

### DIFF
--- a/liveklass-common/build.gradle
+++ b/liveklass-common/build.gradle
@@ -2,6 +2,10 @@ plugins {
 	id 'java-library'
 }
 
+dependencies {
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
 jar {
 	enabled = true
 }

--- a/liveklass-common/src/main/java/com/liveklass/common/error/ExceptionCreator.java
+++ b/liveklass-common/src/main/java/com/liveklass/common/error/ExceptionCreator.java
@@ -1,0 +1,28 @@
+package com.liveklass.common.error;
+
+import com.liveklass.common.error.exception.AbstractException;
+
+import java.lang.reflect.Constructor;
+
+public class ExceptionCreator {
+    @SuppressWarnings("unchecked")
+    private static <T> T createInstance(Class<? extends T> clazz, Object... args) {
+        Constructor<? extends T>[] constructorArray = (Constructor<? extends T>[]) clazz.getDeclaredConstructors();
+        for (Constructor<? extends T> constructor : constructorArray) {
+            try {
+                return constructor.newInstance(args);
+            } catch (Exception ignored) {
+
+            }
+        }
+        throw new RuntimeException("Failed to create HttpException instance");
+    }
+
+    public static AbstractException create(ExceptionInterface e) {
+        return (AbstractException) createInstance(e.getAClass(),e.getErrorCode(), e.getMessage());
+    }
+
+    public static AbstractException create(ExceptionInterface e, String errorLog) {
+        return (AbstractException) createInstance(e.getAClass(), e.getErrorCode(), e.getMessage(), errorLog);
+    }
+}

--- a/liveklass-common/src/main/java/com/liveklass/common/error/ExceptionInterface.java
+++ b/liveklass-common/src/main/java/com/liveklass/common/error/ExceptionInterface.java
@@ -1,0 +1,7 @@
+package com.liveklass.common.error;
+
+public interface ExceptionInterface {
+    String getErrorCode();
+    String getMessage();
+    Class<?> getAClass();
+}

--- a/liveklass-common/src/main/java/com/liveklass/common/error/exception/AbstractException.java
+++ b/liveklass-common/src/main/java/com/liveklass/common/error/exception/AbstractException.java
@@ -1,0 +1,24 @@
+package com.liveklass.common.error.exception;
+
+import lombok.Getter;
+
+@Getter
+public abstract class AbstractException extends RuntimeException {
+    private final String errorCode;
+    private final String message;
+    private final String errorLog;
+
+    public AbstractException(String errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+        this.message = message;
+        this.errorLog = null;
+    }
+
+    public AbstractException(String errorCode, String message, String errorLog) {
+        super(message);
+        this.errorCode = errorCode;
+        this.message = message;
+        this.errorLog = errorLog;
+    }
+}

--- a/liveklass-common/src/main/java/com/liveklass/common/error/exception/BadRequestException.java
+++ b/liveklass-common/src/main/java/com/liveklass/common/error/exception/BadRequestException.java
@@ -1,0 +1,11 @@
+package com.liveklass.common.error.exception;
+
+public class BadRequestException extends AbstractException {
+    public BadRequestException(String errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    public BadRequestException(String errorCode, String message, String errorLog) {
+        super(errorCode, message, errorLog);
+    }
+}

--- a/liveklass-common/src/main/java/com/liveklass/common/error/exception/ConflictException.java
+++ b/liveklass-common/src/main/java/com/liveklass/common/error/exception/ConflictException.java
@@ -1,0 +1,11 @@
+package com.liveklass.common.error.exception;
+
+public class ConflictException extends AbstractException {
+    public ConflictException(final String errorCode, final String message) {
+        super(errorCode, message);
+    }
+
+    public ConflictException(final String errorCode, final String message, final String errorLog) {
+        super(errorCode, message, errorLog);
+    }
+}

--- a/liveklass-common/src/main/java/com/liveklass/common/error/exception/ForbiddenException.java
+++ b/liveklass-common/src/main/java/com/liveklass/common/error/exception/ForbiddenException.java
@@ -1,0 +1,11 @@
+package com.liveklass.common.error.exception;
+
+public class ForbiddenException extends AbstractException {
+    public ForbiddenException(String errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    public ForbiddenException(String errorCode, String message, String errorLog) {
+        super(errorCode, message, errorLog);
+    }
+}

--- a/liveklass-common/src/main/java/com/liveklass/common/error/exception/InternalServerErrorException.java
+++ b/liveklass-common/src/main/java/com/liveklass/common/error/exception/InternalServerErrorException.java
@@ -1,0 +1,11 @@
+package com.liveklass.common.error.exception;
+
+public class InternalServerErrorException extends AbstractException {
+    public InternalServerErrorException(String errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    public InternalServerErrorException(String errorCode, String message, String errorLog) {
+        super(errorCode, message, errorLog);
+    }
+}

--- a/liveklass-common/src/main/java/com/liveklass/common/error/exception/NotFoundException.java
+++ b/liveklass-common/src/main/java/com/liveklass/common/error/exception/NotFoundException.java
@@ -1,0 +1,11 @@
+package com.liveklass.common.error.exception;
+
+public class NotFoundException extends AbstractException {
+    public NotFoundException(String errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    public NotFoundException(String errorCode, String message, String errorLog) {
+        super(errorCode, message, errorLog);
+    }
+}

--- a/liveklass-common/src/main/java/com/liveklass/common/error/exception/ServiceUnavailableException.java
+++ b/liveklass-common/src/main/java/com/liveklass/common/error/exception/ServiceUnavailableException.java
@@ -1,0 +1,11 @@
+package com.liveklass.common.error.exception;
+
+public class ServiceUnavailableException extends AbstractException {
+    public ServiceUnavailableException(String errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    public ServiceUnavailableException(String errorCode, String message, String errorLog) {
+        super(errorCode, message, errorLog);
+    }
+}

--- a/liveklass-common/src/main/java/com/liveklass/common/error/exception/UnauthorizedException.java
+++ b/liveklass-common/src/main/java/com/liveklass/common/error/exception/UnauthorizedException.java
@@ -1,0 +1,11 @@
+package com.liveklass.common.error.exception;
+
+public class UnauthorizedException extends AbstractException {
+    public UnauthorizedException(String errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    public UnauthorizedException(String errorCode, String message, String errorLog) {
+        super(errorCode, message, errorLog);
+    }
+}

--- a/liveklass-common/src/test/java/com/liveklass/common/error/ExceptionCreatorTest.java
+++ b/liveklass-common/src/test/java/com/liveklass/common/error/ExceptionCreatorTest.java
@@ -1,0 +1,125 @@
+package com.liveklass.common.error;
+
+import com.liveklass.common.error.exception.AbstractException;
+import com.liveklass.common.error.exception.BadRequestException;
+import com.liveklass.common.error.exception.ConflictException;
+import com.liveklass.common.error.exception.ForbiddenException;
+import com.liveklass.common.error.exception.InternalServerErrorException;
+import com.liveklass.common.error.exception.NotFoundException;
+import com.liveklass.common.error.exception.ServiceUnavailableException;
+import com.liveklass.common.error.exception.UnauthorizedException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag("UNIT_TEST")
+@DisplayName("ExceptionCreator 단위 테스트")
+class ExceptionCreatorTest {
+
+    enum TestError implements ExceptionInterface {
+        BAD_REQUEST("E400", "잘못된 요청", BadRequestException.class),
+        UNAUTHORIZED("E401", "인증 필요", UnauthorizedException.class),
+        FORBIDDEN("E403", "접근 불가", ForbiddenException.class),
+        NOT_FOUND("E404", "찾을 수 없음", NotFoundException.class),
+        CONFLICT("E409", "충돌 발생", ConflictException.class),
+        INTERNAL_SERVER_ERROR("E500", "서버 오류", InternalServerErrorException.class),
+        SERVICE_UNAVAILABLE("E503", "서비스 불가", ServiceUnavailableException.class);
+
+        private final String errorCode;
+        private final String message;
+        private final Class<?> aClass;
+
+        TestError(String errorCode, String message, Class<?> aClass) {
+            this.errorCode = errorCode;
+            this.message = message;
+            this.aClass = aClass;
+        }
+
+        @Override public String getErrorCode() { return errorCode; }
+        @Override public String getMessage() { return message; }
+        @Override public Class<?> getAClass() { return aClass; }
+    }
+
+    @Nested
+    @DisplayName("create(ExceptionInterface) 메서드는")
+    class Describe_create {
+
+        @Nested
+        @DisplayName("errorLog 없이 호출하면")
+        class Context_without_errorLog {
+
+            @Test
+            @DisplayName("errorCode·message가 설정되고 errorLog는 null이다")
+            void it_creates_exception_without_errorLog() {
+                // given
+                final TestError error = TestError.BAD_REQUEST;
+
+                // when
+                final AbstractException exception = ExceptionCreator.create(error);
+
+                // then
+                assertThat(exception).isInstanceOf(BadRequestException.class);
+                assertThat(exception.getErrorCode()).isEqualTo(error.getErrorCode());
+                assertThat(exception.getMessage()).isEqualTo(error.getMessage());
+                assertThat(exception.getErrorLog()).isNull();
+            }
+
+            @ParameterizedTest(name = "{0} → {1}")
+            @MethodSource("com.liveklass.common.error.ExceptionCreatorTest#exceptionTypeSource")
+            @DisplayName("각 ExceptionInterface 구현체에서 올바른 예외 타입과 필드값이 생성된다")
+            void it_creates_correct_exception_type(
+                    final TestError error,
+                    final Class<? extends AbstractException> expectedType) {
+                // when
+                final AbstractException exception = ExceptionCreator.create(error);
+
+                // then
+                assertThat(exception).isInstanceOf(expectedType);
+                assertThat(exception.getErrorCode()).isEqualTo(error.getErrorCode());
+                assertThat(exception.getMessage()).isEqualTo(error.getMessage());
+            }
+        }
+
+        @Nested
+        @DisplayName("errorLog와 함께 호출하면")
+        class Context_with_errorLog {
+
+            @Test
+            @DisplayName("errorLog가 예외에 설정된다")
+            void it_creates_exception_with_errorLog() {
+                // given
+                final TestError error = TestError.NOT_FOUND;
+                final String errorLog = "상세 디버그 로그";
+
+                // when
+                final AbstractException exception = ExceptionCreator.create(error, errorLog);
+
+                // then
+                assertThat(exception).isInstanceOf(NotFoundException.class);
+                assertThat(exception.getErrorCode()).isEqualTo(error.getErrorCode());
+                assertThat(exception.getMessage()).isEqualTo(error.getMessage());
+                assertThat(exception.getErrorLog()).isEqualTo(errorLog);
+            }
+        }
+    }
+
+    static Stream<Arguments> exceptionTypeSource() {
+        return Stream.of(
+                Arguments.of(TestError.BAD_REQUEST, BadRequestException.class),
+                Arguments.of(TestError.UNAUTHORIZED, UnauthorizedException.class),
+                Arguments.of(TestError.FORBIDDEN, ForbiddenException.class),
+                Arguments.of(TestError.NOT_FOUND, NotFoundException.class),
+                Arguments.of(TestError.CONFLICT, ConflictException.class),
+                Arguments.of(TestError.INTERNAL_SERVER_ERROR, InternalServerErrorException.class),
+                Arguments.of(TestError.SERVICE_UNAVAILABLE, ServiceUnavailableException.class)
+        );
+    }
+}


### PR DESCRIPTION
## 📌 한눈에 보기

| 구분 | 내용 |
| --- | --- |
| 예외 기반 | ExceptionInterface, AbstractException 정의 |
| 4xx 예외 | BadRequest, Unauthorized, Forbidden, NotFound, Conflict |
| 5xx 예외 | InternalServerError, ServiceUnavailable |
| 팩토리 | ExceptionCreator — ExceptionInterface 기반 예외 인스턴스 생성 |
| 테스트 | ExceptionCreator 단위 테스트 (BDD Nested, 전 타입 파라미터화) |

## 🔧 상세 변경

### 1. 공통 예외 기반 타입
- `ExceptionInterface` — errorCode·message·class 조회 계약 정의
- `AbstractException` — errorCode, message, errorLog 보유 공통 추상 예외 기반 정의

### 2. HTTP 상태별 예외 구현체
- `BadRequestException`, `UnauthorizedException`, `ForbiddenException` — 4xx 인증·권한 예외
- `NotFoundException`, `ConflictException`, `ServiceUnavailableException` — 4xx/5xx 리소스·가용성 예외
- `InternalServerErrorException` — 5xx 서버 내부 오류 예외

### 3. 팩토리
- `ExceptionCreator` — `ExceptionInterface`를 받아 리플렉션으로 예외 인스턴스 생성, errorLog 포함 오버로드 지원

### 4. 테스트
- `ExceptionCreatorTest` — BDD Nested 구조, given 입력값 기반 assertion, 전체 예외 타입 `@ParameterizedTest`

## 🧪 검증
- `./gradlew :liveklass-common:test`

## ✅ 체크리스트
- [x] 코드 작성 완료
- [x] 단위 테스트 작성
- [x] 로컬 환경 테스트

## 🚨 Breaking Changes
-