### PR TITLE
liveklass-common 공통 이벤트 계약 추가

### DIFF
--- a/liveklass-common/build.gradle
+++ b/liveklass-common/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+	api 'com.fasterxml.jackson.core:jackson-databind'   // DomainEvent.payload() JsonNode 노출
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/liveklass-common/src/main/java/com/liveklass/common/event/ChannelType.java
+++ b/liveklass-common/src/main/java/com/liveklass/common/event/ChannelType.java
@@ -1,0 +1,6 @@
+package com.liveklass.common.event;
+
+public enum ChannelType {
+    EMAIL,
+    IN_APP
+}

--- a/liveklass-common/src/main/java/com/liveklass/common/event/DomainEvent.java
+++ b/liveklass-common/src/main/java/com/liveklass/common/event/DomainEvent.java
@@ -1,0 +1,17 @@
+package com.liveklass.common.event;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.LocalDateTime;
+
+public interface DomainEvent {
+
+    Topic topic();
+
+    Long recipientId();
+
+    String referenceId();
+
+    LocalDateTime publishedAt();
+
+    JsonNode payload();
+}

--- a/liveklass-common/src/main/java/com/liveklass/common/event/DomainEventPublisher.java
+++ b/liveklass-common/src/main/java/com/liveklass/common/event/DomainEventPublisher.java
@@ -1,0 +1,21 @@
+package com.liveklass.common.event;
+
+/**
+ * 도메인 이벤트 발행 포트.
+ *
+ * <p>lecture-core의 도메인 서비스가 이 포트를 통해 이벤트를 발행한다.
+ * 실제 구현(adapter)은 실행 컨텍스트(liveklass-api, notification-worker)에서 주입된다.
+ *
+ * <pre>{@code
+ * // lecture-core의 EnrollmentService — 포트만 알고 구현체는 모른다
+ * eventPublisher.publish(new EnrollmentCompletedEvent(...));
+ *
+ * // 단위 테스트 — 람다로 간단히 교체
+ * DomainEventPublisher publisher = capturedEvents::add;
+ * }</pre>
+ */
+@FunctionalInterface
+public interface DomainEventPublisher {
+
+    void publish(DomainEvent event);
+}

--- a/liveklass-common/src/main/java/com/liveklass/common/event/Topic.java
+++ b/liveklass-common/src/main/java/com/liveklass/common/event/Topic.java
@@ -1,0 +1,8 @@
+package com.liveklass.common.event;
+
+public enum Topic {
+    LECTURE_ENROLLMENT_COMPLETED,
+    LECTURE_ENROLLMENT_CANCELLED,
+    PAYMENT_CONFIRMED,
+    LECTURE_STARTING_SOON
+}

--- a/liveklass-common/src/test/java/com/liveklass/common/event/CommonEventContractTest.java
+++ b/liveklass-common/src/test/java/com/liveklass/common/event/CommonEventContractTest.java
@@ -1,0 +1,139 @@
+package com.liveklass.common.event;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag("UNIT_TEST")
+@DisplayName("공통 이벤트 계약 단위 테스트")
+class CommonEventContractTest {
+
+    @Nested
+    @DisplayName("Topic enum은")
+    class Describe_topic {
+
+        @Test
+        @DisplayName("문서 기준 이벤트 topic 값을 유지한다")
+        void it_keeps_declared_topics() {
+            // given
+            final Topic[] topics = Topic.values();
+
+            // when
+            final String[] topicNames = new String[topics.length];
+            for (int i = 0; i < topics.length; i++) {
+                topicNames[i] = topics[i].name();
+            }
+
+            // then
+            assertThat(topicNames).containsExactly(
+                    "LECTURE_ENROLLMENT_COMPLETED",
+                    "LECTURE_ENROLLMENT_CANCELLED",
+                    "PAYMENT_CONFIRMED",
+                    "LECTURE_STARTING_SOON"
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("ChannelType enum은")
+    class Describe_channel_type {
+
+        @Test
+        @DisplayName("문서 기준 발송 채널 값을 유지한다")
+        void it_keeps_declared_channel_types() {
+            // given
+            final ChannelType[] channelTypes = ChannelType.values();
+
+            // when
+            final String[] channelTypeNames = new String[channelTypes.length];
+            for (int i = 0; i < channelTypes.length; i++) {
+                channelTypeNames[i] = channelTypes[i].name();
+            }
+
+            // then
+            assertThat(channelTypeNames).containsExactly("EMAIL", "IN_APP");
+        }
+    }
+
+    @Nested
+    @DisplayName("DomainEvent 계약은")
+    class Describe_domain_event {
+
+        @Test
+        @DisplayName("topic, recipientId, referenceId, publishedAt, payload를 그대로 노출한다")
+        void it_exposes_declared_event_fields() {
+            // given
+            final Topic topic = Topic.PAYMENT_CONFIRMED;
+            final Long recipientId = 1L;
+            final String referenceId = "payment-1";
+            final LocalDateTime publishedAt = LocalDateTime.of(2026, 4, 24, 12, 30);
+            final JsonNode payload = JsonNodeFactory.instance.objectNode()
+                    .put("title", "결제 완료")
+                    .put("amount", 10000);
+            final DomainEvent event = new TestDomainEvent(
+                    topic,
+                    recipientId,
+                    referenceId,
+                    publishedAt,
+                    payload
+            );
+
+            // when
+            final Topic actualTopic = event.topic();
+            final Long actualRecipientId = event.recipientId();
+            final String actualReferenceId = event.referenceId();
+            final LocalDateTime actualPublishedAt = event.publishedAt();
+            final JsonNode actualPayload = event.payload();
+
+            // then
+            assertThat(actualTopic).isEqualTo(topic);
+            assertThat(actualRecipientId).isEqualTo(recipientId);
+            assertThat(actualReferenceId).isEqualTo(referenceId);
+            assertThat(actualPublishedAt).isEqualTo(publishedAt);
+            assertThat(actualPayload).isEqualTo(payload);
+        }
+    }
+
+    @Nested
+    @DisplayName("DomainEventPublisher는")
+    class Describe_domain_event_publisher {
+
+        @Test
+        @DisplayName("전달받은 DomainEvent를 publish 메서드로 위임한다")
+        void it_publishes_domain_event() {
+            // given
+            final DomainEvent event = new TestDomainEvent(
+                    Topic.LECTURE_ENROLLMENT_COMPLETED,
+                    2L,
+                    "enrollment-1",
+                    LocalDateTime.of(2026, 4, 24, 13, 0),
+                    JsonNodeFactory.instance.objectNode().put("lectureId", 10L)
+            );
+            final AtomicReference<DomainEvent> publishedEvent = new AtomicReference<>();
+            final DomainEventPublisher publisher = publishedEvent::set;
+
+            // when
+            publisher.publish(event);
+
+            // then
+            assertThat(publishedEvent.get()).isSameAs(event);
+        }
+    }
+
+    record TestDomainEvent(
+            Topic topic,
+            Long recipientId,
+            String referenceId,
+            LocalDateTime publishedAt,
+            JsonNode payload
+    ) implements DomainEvent {
+    }
+}


### PR DESCRIPTION
## 📌 한눈에 보기

| 구분 | 내용 |
| --- | --- |
| 공통 계약 | `Topic`, `ChannelType`, `DomainEvent`, `DomainEventPublisher` 추가 |
| build | `liveklass-common`에 Jackson `api` 의존성 추가 |
| 검증 | `CommonEventContractTest` 추가 및 common/core/edge compile 확인 |

## 🔧 상세 변경

### 1. 공통 이벤트 타입 정리
- `Topic`, `ChannelType` enum을 추가해 공통 이벤트 topic과 채널 계약 정의
- `DomainEvent` 인터페이스를 추가해 `topic`, `recipientId`, `referenceId`, `publishedAt`, `payload` 계약 정의

### 2. 이벤트 발행 포트 및 검증 추가
- `DomainEventPublisher` 인터페이스를 추가해 core 모듈의 이벤트 발행 경계 분리
- `liveklass-common/build.gradle`에 Jackson `api` 의존성을 추가해 `JsonNode` 공개 계약 노출
- `CommonEventContractTest`를 추가해 enum/interface/publisher 최소 계약 검증

## 🧪 검증
- `.\\gradlew.bat :liveklass-common:compileJava`
- `.\\gradlew.bat :liveklass-common:test`
- `.\\gradlew.bat :lecture-core:compileJava :notification-core:compileJava :liveklass-api:compileJava :notification-worker:compileJava`

## ✅ 체크리스트
- [x] 코드 작성 완료
- [x] 단위 테스트 작성
- [x] 로컬 환경 테스트

## 🔗 관련 이슈
- Closes #4
- Closes #5
- Closes #3
- Related #7

## 🚨 Breaking Changes
- 없음