### PR TITLE
liveklass-common 채널별 payload builder 추가

### DIFF
--- a/liveklass-common/src/main/java/com/liveklass/common/event/DomainEvent.java
+++ b/liveklass-common/src/main/java/com/liveklass/common/event/DomainEvent.java
@@ -1,8 +1,38 @@
 package com.liveklass.common.event;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
 import java.time.LocalDateTime;
 
+/**
+ * 도메인 이벤트 계약.
+ *
+ * <p>수강신청 완료, 결제 확정 등 도메인 사실을 표현하는 모든 이벤트가 구현한다.
+ * 이벤트 record는 {@link #payload()}를 통해 채널별 최소 계약을 만족하는 JSON을 반환한다.
+ *
+ * <ul>
+ *   <li>IN_APP: {@code title}, {@code body} 필수
+ *   <li>EMAIL: {@code subject}, {@code body}, {@code metadata.recipientEmail} 필수
+ * </ul>
+ *
+ * <p>{@code channelType}은 이 인터페이스에 노출하지 않는다.
+ * 채널 결정은 {@code liveklass-api}의 {@code TopicChannelPolicy}가 담당한다.
+ *
+ * <pre>{@code
+ * public record EnrollmentCompletedEvent(...) implements DomainEvent {
+ *
+ *     @Override public Topic topic() { return Topic.LECTURE_ENROLLMENT_COMPLETED; }
+ *
+ *     @Override
+ *     public JsonNode payload() {
+ *         return InAppPayload.builder("수강 신청이 완료되었습니다", lectureTitle + " 수강 신청이 완료되었습니다.")
+ *             .metadata("screen", "LECTURE_DETAIL")
+ *             .metadata("enrollmentId", enrollmentId)
+ *             .build();
+ *     }
+ * }
+ * }</pre>
+ */
 public interface DomainEvent {
 
     Topic topic();

--- a/liveklass-common/src/main/java/com/liveklass/common/event/EmailPayload.java
+++ b/liveklass-common/src/main/java/com/liveklass/common/event/EmailPayload.java
@@ -1,0 +1,73 @@
+package com.liveklass.common.event;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+import java.util.Objects;
+
+/**
+ * EMAIL 채널 payload 빌더.
+ *
+ * <p>{@code subject}, {@code body}, {@code recipientEmail}은 필수다.
+ * 빌더 생성 시 전달하므로 누락이 컴파일 시점에 드러난다.
+ *
+ * <p>{@code body}는 {@link JsonNode}로 받아 표현 방식을 caller가 결정한다.
+ * 문자열 편의 오버로드를 통해 기존 방식도 유지된다.
+ *
+ * <pre>{@code
+ * // 텍스트 본문
+ * EmailPayload.builder("제목", "본문 텍스트", recipientEmail).build();
+ *
+ * // HTML 본문
+ * EmailPayload.builder("제목", TextNode.valueOf("<h1>HTML</h1>"), recipientEmail)
+ *     .metadata("bodyType", "HTML")
+ *     .build();
+ *
+ * // 구조화된 본문 (카드 타입)
+ * ObjectNode card = JsonNodeFactory.instance.objectNode()
+ *     .put("headline", "결제가 완료됐습니다")
+ *     .put("cta", "영수증 보기");
+ * EmailPayload.builder("제목", card, recipientEmail)
+ *     .metadata("bodyType", "CARD")
+ *     .build();
+ * }</pre>
+ */
+public final class EmailPayload {
+
+    private EmailPayload() {}
+
+    /** 텍스트 본문 편의 오버로드. body를 TextNode로 변환한다. */
+    public static Builder builder(final String subject, final String body, final String recipientEmail) {
+        return new Builder(subject, TextNode.valueOf(body), recipientEmail);
+    }
+
+    /** body 표현 방식을 caller가 직접 결정하는 오버로드. 텍스트/HTML/구조화 본문 모두 가능. */
+    public static Builder builder(final String subject, final JsonNode body, final String recipientEmail) {
+        return new Builder(subject, body, recipientEmail);
+    }
+
+    public static final class Builder extends PayloadBuilder<Builder> {
+
+        private final String subject;
+        private final JsonNode body;
+
+        private Builder(final String subject, final JsonNode body, final String recipientEmail) {
+            this.subject = Objects.requireNonNull(subject,        "subject must not be null");
+            this.body    = Objects.requireNonNull(body,           "body must not be null");
+            Objects.requireNonNull(recipientEmail, "recipientEmail must not be null");
+            metadata.put("recipientEmail", recipientEmail);
+        }
+
+        /** EMAIL 최소 계약(subject, body, metadata.recipientEmail)을 만족하는 JsonNode를 반환한다. */
+        @Override
+        public JsonNode build() {
+            final ObjectNode root = JsonNodeFactory.instance.objectNode();
+            root.put("subject", subject);
+            root.set("body",    body);
+            root.set("metadata", metadata);
+            return root;
+        }
+    }
+}

--- a/liveklass-common/src/main/java/com/liveklass/common/event/InAppPayload.java
+++ b/liveklass-common/src/main/java/com/liveklass/common/event/InAppPayload.java
@@ -1,0 +1,50 @@
+package com.liveklass.common.event;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.Objects;
+
+/**
+ * IN_APP 채널 payload 빌더.
+ *
+ * <p>{@code title}과 {@code body}는 필수다. 빌더 생성 시 전달하므로 누락이 컴파일 시점에 드러난다.
+ * 추가 컨텍스트는 {@link Builder#metadata} 체이닝으로 확장한다.
+ *
+ * <pre>{@code
+ * JsonNode payload = InAppPayload.builder("수강 신청 완료", lectureTitle + " 수강 신청이 완료되었습니다.")
+ *     .metadata("screen", "LECTURE_DETAIL")
+ *     .metadata("lectureId", lectureId)
+ *     .build();
+ * }</pre>
+ */
+public final class InAppPayload {
+
+    private InAppPayload() {}
+
+    public static Builder builder(final String title, final String body) {
+        return new Builder(title, body);
+    }
+
+    public static final class Builder extends PayloadBuilder<Builder> {
+
+        private final String title;
+        private final String body;
+
+        private Builder(final String title, final String body) {
+            this.title = Objects.requireNonNull(title, "title must not be null");
+            this.body  = Objects.requireNonNull(body,  "body must not be null");
+        }
+
+        /** IN_APP 최소 계약(title, body, metadata)을 만족하는 JsonNode를 반환한다. */
+        @Override
+        public JsonNode build() {
+            final ObjectNode root = JsonNodeFactory.instance.objectNode();
+            root.put("title", title);
+            root.put("body",  body);
+            root.set("metadata", metadata);
+            return root;
+        }
+    }
+}

--- a/liveklass-common/src/main/java/com/liveklass/common/event/PayloadBuilder.java
+++ b/liveklass-common/src/main/java/com/liveklass/common/event/PayloadBuilder.java
@@ -1,0 +1,55 @@
+package com.liveklass.common.event;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * 채널별 payload 빌더의 공통 추상 클래스.
+ *
+ * <p>새 채널 추가 시 이 클래스를 상속하고, 채널 고유의 필수 필드만 정의하면 된다.
+ * {@link #metadata} 체이닝은 모든 채널 빌더에서 공통으로 사용할 수 있다.
+ *
+ * <pre>{@code
+ * // 새 채널 추가 예시
+ * public final class SmsPayload {
+ *     public static Builder builder(String message, String phoneNumber) {
+ *         return new Builder(message, phoneNumber);
+ *     }
+ *
+ *     public static final class Builder extends PayloadBuilder<Builder> {
+ *         // 채널 고유 필수 필드만 추가
+ *     }
+ * }
+ * }</pre>
+ *
+ * @param <T> 구체 빌더 타입 (메서드 체이닝 반환 타입에 사용)
+ */
+public abstract class PayloadBuilder<T extends PayloadBuilder<T>> {
+
+    protected final ObjectNode metadata = JsonNodeFactory.instance.objectNode();
+
+    /** metadata에 문자열 값을 추가한다. */
+    @SuppressWarnings("unchecked")
+    public final T metadata(final String key, final String value) {
+        metadata.put(key, value);
+        return (T) this;
+    }
+
+    /** metadata에 숫자 값을 추가한다. */
+    @SuppressWarnings("unchecked")
+    public final T metadata(final String key, final long value) {
+        metadata.put(key, value);
+        return (T) this;
+    }
+
+    /** metadata에 불리언 값을 추가한다. */
+    @SuppressWarnings("unchecked")
+    public final T metadata(final String key, final boolean value) {
+        metadata.put(key, value);
+        return (T) this;
+    }
+
+    /** 채널별 최소 계약을 만족하는 {@link JsonNode}를 반환한다. */
+    public abstract JsonNode build();
+}

--- a/liveklass-common/src/test/java/com/liveklass/common/event/EmailPayloadTest.java
+++ b/liveklass-common/src/test/java/com/liveklass/common/event/EmailPayloadTest.java
@@ -1,0 +1,193 @@
+package com.liveklass.common.event;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+@Tag("UNIT_TEST")
+@DisplayName("EmailPayload 빌더는")
+class EmailPayloadTest {
+
+    @Nested
+    @DisplayName("텍스트 본문 builder()는")
+    class Describe_text_builder {
+
+        @Test
+        @DisplayName("subject와 body를 JSON 최상위 필드로 반환한다")
+        void it_returns_subject_and_body_as_root_fields() {
+            // given
+            final String subject = "[Live Klass] 결제 완료";
+            final String body = "49,000원 결제가 승인되었습니다.";
+            final String recipientEmail = "user@example.com";
+
+            // when
+            final JsonNode payload = EmailPayload.builder(subject, body, recipientEmail).build();
+
+            // then
+            assertThat(payload.get("subject").asText()).isEqualTo(subject);
+            assertThat(payload.get("body").asText()).isEqualTo(body);
+        }
+
+        @Test
+        @DisplayName("recipientEmail이 metadata.recipientEmail에 들어간다")
+        void it_puts_recipient_email_under_metadata() {
+            // given
+            final String recipientEmail = "user@example.com";
+
+            // when
+            final JsonNode payload = EmailPayload.builder("제목", "본문", recipientEmail).build();
+
+            // then
+            assertThat(payload.get("metadata").get("recipientEmail").asText())
+                    .isEqualTo(recipientEmail);
+        }
+
+        @Test
+        @DisplayName("metadata() 체이닝으로 추가한 값이 기존 recipientEmail과 함께 들어간다")
+        void it_merges_extra_metadata_with_recipient_email() {
+            // given
+            final String recipientEmail = "user@example.com";
+            final String paymentId = "pay_001";
+            final long amount = 49000L;
+
+            // when
+            final JsonNode payload = EmailPayload.builder("제목", "본문", recipientEmail)
+                    .metadata("paymentId", paymentId)
+                    .metadata("amount", amount)
+                    .build();
+
+            // then
+            final JsonNode metadata = payload.get("metadata");
+            assertThat(metadata.get("recipientEmail").asText()).isEqualTo(recipientEmail);
+            assertThat(metadata.get("paymentId").asText()).isEqualTo(paymentId);
+            assertThat(metadata.get("amount").asLong()).isEqualTo(amount);
+        }
+    }
+
+    @Nested
+    @DisplayName("HTML 본문 builder()는")
+    class Describe_html_builder {
+
+        @Test
+        @DisplayName("body가 HTML 문자열 TextNode로 직렬화된다")
+        void it_serializes_html_body_as_text_node() {
+            // given
+            final String html = "<h1>결제 완료</h1><p>49,000원 결제가 승인되었습니다.</p>";
+            final JsonNode htmlBody = TextNode.valueOf(html);
+
+            // when
+            final JsonNode payload = EmailPayload.builder("제목", htmlBody, "user@example.com")
+                    .metadata("bodyType", "HTML")
+                    .build();
+
+            // then
+            assertThat(payload.get("body").asText()).isEqualTo(html);
+            assertThat(payload.get("metadata").get("bodyType").asText()).isEqualTo("HTML");
+        }
+    }
+
+    @Nested
+    @DisplayName("구조화된 본문 builder()는")
+    class Describe_structured_builder {
+
+        @Test
+        @DisplayName("body가 ObjectNode로 직렬화된다")
+        void it_serializes_structured_body_as_object_node() {
+            // given
+            final String headline = "결제가 완료됐습니다";
+            final String cta = "영수증 보기";
+            final ObjectNode card = JsonNodeFactory.instance.objectNode()
+                    .put("headline", headline)
+                    .put("cta", cta);
+
+            // when
+            final JsonNode payload = EmailPayload.builder("제목", card, "user@example.com")
+                    .metadata("bodyType", "CARD")
+                    .build();
+
+            // then
+            final JsonNode body = payload.get("body");
+            assertThat(body.get("headline").asText()).isEqualTo(headline);
+            assertThat(body.get("cta").asText()).isEqualTo(cta);
+            assertThat(payload.get("metadata").get("bodyType").asText()).isEqualTo("CARD");
+        }
+    }
+
+    @Nested
+    @DisplayName("EMAIL 최소 계약은")
+    class Describe_minimum_contract {
+
+        @Test
+        @DisplayName("subject, body, metadata.recipientEmail을 모두 포함한다")
+        void it_satisfies_email_minimum_contract() {
+            // given & when
+            final JsonNode payload = EmailPayload.builder("제목", "본문", "user@example.com").build();
+
+            // then
+            assertThat(payload.has("subject")).isTrue();
+            assertThat(payload.has("body")).isTrue();
+            assertThat(payload.get("metadata").has("recipientEmail")).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("builder()는")
+    class Describe_builder_validation {
+
+        @Test
+        @DisplayName("subject가 null이면 NPE를 던진다")
+        void it_throws_when_subject_is_null() {
+            // given
+            final String nullSubject = null;
+
+            // when & then
+            assertThatNullPointerException()
+                    .isThrownBy(() -> EmailPayload.builder(nullSubject, "본문", "user@example.com"))
+                    .withMessageContaining("subject");
+        }
+
+        @Test
+        @DisplayName("body(String)가 null이면 NPE를 던진다")
+        void it_throws_when_string_body_is_null() {
+            // given
+            final String nullBody = null;
+
+            // when & then
+            assertThatNullPointerException()
+                    .isThrownBy(() -> EmailPayload.builder("제목", nullBody, "user@example.com"))
+                    .withMessageContaining("body");
+        }
+
+        @Test
+        @DisplayName("body(JsonNode)가 null이면 NPE를 던진다")
+        void it_throws_when_json_body_is_null() {
+            // given
+            final JsonNode nullBody = null;
+
+            // when & then
+            assertThatNullPointerException()
+                    .isThrownBy(() -> EmailPayload.builder("제목", nullBody, "user@example.com"))
+                    .withMessageContaining("body");
+        }
+
+        @Test
+        @DisplayName("recipientEmail이 null이면 NPE를 던진다")
+        void it_throws_when_recipient_email_is_null() {
+            // given
+            final String nullEmail = null;
+
+            // when & then
+            assertThatNullPointerException()
+                    .isThrownBy(() -> EmailPayload.builder("제목", "본문", nullEmail))
+                    .withMessageContaining("recipientEmail");
+        }
+    }
+}

--- a/liveklass-common/src/test/java/com/liveklass/common/event/InAppPayloadTest.java
+++ b/liveklass-common/src/test/java/com/liveklass/common/event/InAppPayloadTest.java
@@ -1,0 +1,112 @@
+package com.liveklass.common.event;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+@Tag("UNIT_TEST")
+@DisplayName("InAppPayload 빌더는")
+class InAppPayloadTest {
+
+    @Nested
+    @DisplayName("build()는")
+    class Describe_build {
+
+        @Test
+        @DisplayName("title과 body를 JSON 최상위 필드로 반환한다")
+        void it_returns_title_and_body_as_root_fields() {
+            // given
+            final String title = "수강 신청 완료";
+            final String body = "Spring Boot 수강 신청이 완료되었습니다.";
+
+            // when
+            final JsonNode payload = InAppPayload.builder(title, body).build();
+
+            // then
+            assertThat(payload.get("title").asText()).isEqualTo(title);
+            assertThat(payload.get("body").asText()).isEqualTo(body);
+        }
+
+        @Test
+        @DisplayName("metadata 없이 호출하면 빈 metadata 객체를 포함한다")
+        void it_includes_empty_metadata_when_none_added() {
+            // given
+            final String title = "제목";
+            final String body = "본문";
+
+            // when
+            final JsonNode payload = InAppPayload.builder(title, body).build();
+
+            // then
+            assertThat(payload.get("metadata").isObject()).isTrue();
+            assertThat(payload.get("metadata").isEmpty()).isTrue();
+        }
+
+        @Test
+        @DisplayName("metadata() 체이닝으로 추가한 값이 metadata 객체 안에 들어간다")
+        void it_puts_metadata_entries_under_metadata_node() {
+            // given
+            final String screen = "LECTURE_DETAIL";
+            final long lectureId = 42L;
+            final boolean isNew = true;
+
+            // when
+            final JsonNode payload = InAppPayload.builder("제목", "본문")
+                    .metadata("screen", screen)
+                    .metadata("lectureId", lectureId)
+                    .metadata("isNew", isNew)
+                    .build();
+
+            // then
+            final JsonNode metadata = payload.get("metadata");
+            assertThat(metadata.get("screen").asText()).isEqualTo(screen);
+            assertThat(metadata.get("lectureId").asLong()).isEqualTo(lectureId);
+            assertThat(metadata.get("isNew").asBoolean()).isEqualTo(isNew);
+        }
+
+        @Test
+        @DisplayName("IN_APP 최소 계약 필드(title, body)를 모두 포함한다")
+        void it_satisfies_in_app_minimum_contract() {
+            // given & when
+            final JsonNode payload = InAppPayload.builder("제목", "본문").build();
+
+            // then
+            assertThat(payload.has("title")).isTrue();
+            assertThat(payload.has("body")).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("builder()는")
+    class Describe_builder {
+
+        @Test
+        @DisplayName("title이 null이면 NPE를 던진다")
+        void it_throws_when_title_is_null() {
+            // given
+            final String nullTitle = null;
+
+            // when & then
+            assertThatNullPointerException()
+                    .isThrownBy(() -> InAppPayload.builder(nullTitle, "본문"))
+                    .withMessageContaining("title");
+        }
+
+        @Test
+        @DisplayName("body가 null이면 NPE를 던진다")
+        void it_throws_when_body_is_null() {
+            // given
+            final String nullBody = null;
+
+            // when & then
+            assertThatNullPointerException()
+                    .isThrownBy(() -> InAppPayload.builder("제목", nullBody))
+                    .withMessageContaining("body");
+        }
+    }
+}


### PR DESCRIPTION
## 📌 한눈에 보기

| 구분 | 내용 |
| --- | --- |
| payload 계약 | `DomainEvent` Javadoc에 채널별 최소 payload 계약 설명 추가 |
| 공통 builder | `PayloadBuilder`, `InAppPayload`, `EmailPayload` 추가 |
| 검증 | payload builder 단위 테스트 추가 및 `liveklass-common:test` 검증 |

## 🔧 상세 변경

### 1. 채널별 payload builder 추가
- `PayloadBuilder`를 추가해 metadata 체이닝 공통 추상 builder 정의
- `InAppPayload`를 추가해 IN_APP 최소 payload 구조를 재사용 가능한 builder로 정리
- `EmailPayload`를 추가해 EMAIL 최소 payload 구조와 `recipientEmail` 계약을 builder로 정리

### 2. 공통 계약 문서화 및 테스트 추가
- `DomainEvent` Javadoc을 보강해 payload 최소 계약과 사용 예시 문서화
- `EmailPayloadTest`, `InAppPayloadTest`를 추가해 최소 계약과 null validation 검증

## 🧪 검증
- `.\\gradlew.bat :liveklass-common:test`
- `.\\gradlew.bat :liveklass-common:test --tests "*EmailPayloadTest" --tests "*InAppPayloadTest"`

## ✅ 체크리스트
- [x] 코드 작성 완료
- [x] 단위 테스트 작성
- [x] 로컬 환경 테스트

## 🔗 관련 이슈
- Closes #9
- Depends on #8

## 🚨 Breaking Changes
- 없음