### PR TITLE
common 의존성 전략과 검증 기준 정리

### DIFF
--- a/lecture-core/build.gradle
+++ b/lecture-core/build.gradle
@@ -4,6 +4,7 @@ plugins {
 }
 
 dependencies {
+	implementation project(':liveklass-common')                   // DomainEvent 등 공통 계약 내부 의존
 	api 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'

--- a/liveklass-common/README.md
+++ b/liveklass-common/README.md
@@ -1,0 +1,45 @@
+# liveklass-common
+
+`liveklass-common` is the shared contract module for the notification flow.
+It owns common event types and the minimum verification commands for downstream modules.
+
+## Compile Verification
+
+Run these commands when the common event contract changes.
+
+```powershell
+.\gradlew.bat :liveklass-common:compileJava
+.\gradlew.bat :lecture-core:compileJava :notification-core:compileJava :liveklass-api:compileJava :notification-worker:compileJava
+```
+
+Checks:
+
+- `liveklass-common` public API compiles after enum, interface, or payload contract changes
+- `lecture-core` and `notification-core` keep common as an internal `implementation` dependency
+- edge modules add a direct common dependency only when they compile against common types themselves
+
+## Test Verification
+
+Run these commands before merging common contract changes.
+
+```powershell
+.\gradlew.bat :liveklass-common:test
+.\gradlew.bat :liveklass-common:test --tests "*CommonEventContractTest"
+.\gradlew.bat :liveklass-common:test --tests "*EmailPayloadTest" --tests "*InAppPayloadTest"
+```
+
+Checks:
+
+- `Topic`, `ChannelType`, `DomainEvent`, and `DomainEventPublisher` keep their expected contracts
+- channel payload builders satisfy the minimum `IN_APP` and `EMAIL` payload shape
+- null validation on payload builders stays intact
+
+## Contract Checklist
+
+Review these points whenever the common contract changes.
+
+- Adding or renaming `Topic` or `ChannelType` values can affect downstream config keys and persisted values
+- Changing the `DomainEvent` signature affects `lecture-core`, `notification-core`, `liveklass-api`, and `notification-worker`
+- Changing `DomainEventPublisher` affects adapter implementations in edge modules
+- Changing payload builder fields affects event payload shape used by notification registration and dispatch
+- If an edge module starts importing common types directly, add `project(':liveklass-common')` there instead of relying on transitive exposure

--- a/notification-core/build.gradle
+++ b/notification-core/build.gradle
@@ -4,7 +4,8 @@ plugins {
 }
 
 dependencies {
-	api 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation project(':liveklass-common')                   // Topic, ChannelType 등 공통 계약 내부 의존
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 }


### PR DESCRIPTION
## 📌 한눈에 보기

| 구분 | 내용 |
| --- | --- |
| 의존성 전략 | `lecture-core`, `notification-core`가 `liveklass-common`을 `implementation`으로 사용하도록 정리 |
| 검증 문서 | `liveklass-common/README.md`에 compile/test 검증 커맨드와 체크포인트 추가 |
| 검증 | downstream compile 및 common test 재검증 완료 |

## 🔧 상세 변경

### 1. common 직접 의존 전략 정리
- `lecture-core/build.gradle`에 `liveklass-common` implementation 의존성을 추가해 공통 계약을 내부 의존으로 정리
- `notification-core/build.gradle`에 `liveklass-common` implementation 의존성을 추가해 공통 계약을 내부 의존으로 정리

### 2. 검증 기준 문서화
- `liveklass-common/README.md`를 추가해 compile 검증 커맨드, test 검증 커맨드, 계약 체크포인트를 정리
- edge 모듈이 common 타입을 직접 import할 때만 직접 의존을 추가하는 기준을 문서화

## 🧪 검증
- `.\\gradlew.bat :lecture-core:compileJava :notification-core:compileJava :liveklass-api:compileJava :notification-worker:compileJava`
- `.\\gradlew.bat :liveklass-common:test`

## ✅ 체크리스트
- [x] 코드 작성 완료
- [x] 단위 테스트/검증 작성 또는 정리 완료
- [x] 로컬 환경 테스트

## 🔗 관련 이슈
- Closes #6
- Closes #7

## 🚨 Breaking Changes
- 없음