### PR TITLE
lecture-core 도메인 모델 추가

### DIFF
--- a/lecture-core/src/main/java/com/liveklass/lecture/domain/Enrollment.java
+++ b/lecture-core/src/main/java/com/liveklass/lecture/domain/Enrollment.java
@@ -1,0 +1,44 @@
+package com.liveklass.lecture.domain;
+
+import com.liveklass.lecture.domain.id.EnrollmentId;
+import com.liveklass.lecture.domain.id.LectureId;
+import com.liveklass.lecture.domain.id.UserId;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public record Enrollment(
+        EnrollmentId id,
+        LectureId lectureId,
+        UserId userId,
+        EnrollmentStatus status,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public Enrollment {
+        Objects.requireNonNull(lectureId, "lectureId must not be null");
+        Objects.requireNonNull(userId, "userId must not be null");
+        Objects.requireNonNull(status, "status must not be null");
+        Objects.requireNonNull(createdAt, "createdAt must not be null");
+        Objects.requireNonNull(updatedAt, "updatedAt must not be null");
+    }
+
+    public static Enrollment create(
+            final LectureId lectureId,
+            final UserId userId,
+            final LocalDateTime createdAt
+    ) {
+        final LocalDateTime now = Objects.requireNonNull(createdAt, "createdAt must not be null");
+        return new Enrollment(null, lectureId, userId, EnrollmentStatus.ENROLLED, now, now);
+    }
+
+    public Enrollment cancel(final LocalDateTime cancelledAt) {
+        Objects.requireNonNull(cancelledAt, "cancelledAt must not be null");
+
+        if (status == EnrollmentStatus.CANCELLED) {
+            return this;
+        }
+
+        return new Enrollment(id, lectureId, userId, EnrollmentStatus.CANCELLED, createdAt, cancelledAt);
+    }
+}

--- a/lecture-core/src/main/java/com/liveklass/lecture/domain/EnrollmentStatus.java
+++ b/lecture-core/src/main/java/com/liveklass/lecture/domain/EnrollmentStatus.java
@@ -1,0 +1,6 @@
+package com.liveklass.lecture.domain;
+
+public enum EnrollmentStatus {
+    ENROLLED,
+    CANCELLED
+}

--- a/lecture-core/src/main/java/com/liveklass/lecture/domain/Lecture.java
+++ b/lecture-core/src/main/java/com/liveklass/lecture/domain/Lecture.java
@@ -1,0 +1,25 @@
+package com.liveklass.lecture.domain;
+
+import com.liveklass.lecture.domain.id.LectureId;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public record Lecture(
+        LectureId id,
+        String title,
+        LocalDateTime startAt,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public Lecture {
+        Objects.requireNonNull(title, "title must not be null");
+        Objects.requireNonNull(startAt, "startAt must not be null");
+        Objects.requireNonNull(createdAt, "createdAt must not be null");
+        Objects.requireNonNull(updatedAt, "updatedAt must not be null");
+
+        if (title.isBlank()) {
+            throw new IllegalArgumentException("title must not be blank");
+        }
+    }
+}

--- a/lecture-core/src/main/java/com/liveklass/lecture/domain/event/EnrollmentCancelledEvent.java
+++ b/lecture-core/src/main/java/com/liveklass/lecture/domain/event/EnrollmentCancelledEvent.java
@@ -1,0 +1,59 @@
+package com.liveklass.lecture.domain.event;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.liveklass.common.event.DomainEvent;
+import com.liveklass.common.event.InAppPayload;
+import com.liveklass.common.event.Topic;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public record EnrollmentCancelledEvent(
+        Long enrollmentId,
+        Long lectureId,
+        Long userId,
+        String lectureTitle,
+        String cancelReason,
+        Long recipientId,
+        String referenceId,
+        LocalDateTime publishedAt
+) implements DomainEvent {
+    public EnrollmentCancelledEvent {
+        Objects.requireNonNull(enrollmentId, "enrollmentId must not be null");
+        Objects.requireNonNull(lectureId, "lectureId must not be null");
+        Objects.requireNonNull(userId, "userId must not be null");
+        Objects.requireNonNull(lectureTitle, "lectureTitle must not be null");
+        Objects.requireNonNull(cancelReason, "cancelReason must not be null");
+        Objects.requireNonNull(recipientId, "recipientId must not be null");
+        Objects.requireNonNull(referenceId, "referenceId must not be null");
+        Objects.requireNonNull(publishedAt, "publishedAt must not be null");
+
+        if (lectureTitle.isBlank()) {
+            throw new IllegalArgumentException("lectureTitle must not be blank");
+        }
+        if (cancelReason.isBlank()) {
+            throw new IllegalArgumentException("cancelReason must not be blank");
+        }
+        if (referenceId.isBlank()) {
+            throw new IllegalArgumentException("referenceId must not be blank");
+        }
+    }
+
+    @Override
+    public Topic topic() {
+        return Topic.LECTURE_ENROLLMENT_CANCELLED;
+    }
+
+    @Override
+    public JsonNode payload() {
+        return InAppPayload.builder(
+                        "수강 신청이 취소되었습니다",
+                        "취소된 강의: " + lectureTitle
+                )
+                .metadata("severity", "INFO")
+                .metadata("enrollmentId", enrollmentId)
+                .metadata("cancelReason", cancelReason)
+                .metadata("cancelledAt", publishedAt.toString())
+                .build();
+    }
+}

--- a/lecture-core/src/main/java/com/liveklass/lecture/domain/event/EnrollmentCompletedEvent.java
+++ b/lecture-core/src/main/java/com/liveklass/lecture/domain/event/EnrollmentCompletedEvent.java
@@ -1,0 +1,55 @@
+package com.liveklass.lecture.domain.event;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.liveklass.common.event.DomainEvent;
+import com.liveklass.common.event.InAppPayload;
+import com.liveklass.common.event.Topic;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public record EnrollmentCompletedEvent(
+        Long enrollmentId,
+        Long lectureId,
+        Long userId,
+        String lectureTitle,
+        Long recipientId,
+        String referenceId,
+        LocalDateTime publishedAt
+) implements DomainEvent {
+    public EnrollmentCompletedEvent {
+        Objects.requireNonNull(enrollmentId, "enrollmentId must not be null");
+        Objects.requireNonNull(lectureId, "lectureId must not be null");
+        Objects.requireNonNull(userId, "userId must not be null");
+        Objects.requireNonNull(lectureTitle, "lectureTitle must not be null");
+        Objects.requireNonNull(recipientId, "recipientId must not be null");
+        Objects.requireNonNull(referenceId, "referenceId must not be null");
+        Objects.requireNonNull(publishedAt, "publishedAt must not be null");
+
+        if (lectureTitle.isBlank()) {
+            throw new IllegalArgumentException("lectureTitle must not be blank");
+        }
+        if (referenceId.isBlank()) {
+            throw new IllegalArgumentException("referenceId must not be blank");
+        }
+    }
+
+    @Override
+    public Topic topic() {
+        return Topic.LECTURE_ENROLLMENT_COMPLETED;
+    }
+
+    @Override
+    public JsonNode payload() {
+        return InAppPayload.builder(
+                        "수강 신청이 완료되었습니다",
+                        lectureTitle + " 수강 신청이 완료되었습니다."
+                )
+                .metadata("screen", "LECTURE_DETAIL")
+                .metadata("enrollmentId", enrollmentId)
+                .metadata("lectureId", lectureId)
+                .metadata("lectureTitle", lectureTitle)
+                .metadata("enrolledAt", publishedAt.toString())
+                .build();
+    }
+}

--- a/lecture-core/src/main/java/com/liveklass/lecture/domain/event/PaymentConfirmedEvent.java
+++ b/lecture-core/src/main/java/com/liveklass/lecture/domain/event/PaymentConfirmedEvent.java
@@ -1,0 +1,69 @@
+package com.liveklass.lecture.domain.event;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.liveklass.common.event.DomainEvent;
+import com.liveklass.common.event.EmailPayload;
+import com.liveklass.common.event.Topic;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public record PaymentConfirmedEvent(
+        String paymentId,
+        Long userId,
+        Long enrollmentId,
+        long amount,
+        String currency,
+        String recipientEmail,
+        Long recipientId,
+        String referenceId,
+        LocalDateTime publishedAt
+) implements DomainEvent {
+    public PaymentConfirmedEvent {
+        Objects.requireNonNull(paymentId, "paymentId must not be null");
+        Objects.requireNonNull(userId, "userId must not be null");
+        Objects.requireNonNull(enrollmentId, "enrollmentId must not be null");
+        Objects.requireNonNull(currency, "currency must not be null");
+        Objects.requireNonNull(recipientEmail, "recipientEmail must not be null");
+        Objects.requireNonNull(recipientId, "recipientId must not be null");
+        Objects.requireNonNull(referenceId, "referenceId must not be null");
+        Objects.requireNonNull(publishedAt, "publishedAt must not be null");
+
+        if (paymentId.isBlank()) {
+            throw new IllegalArgumentException("paymentId must not be blank");
+        }
+        if (currency.isBlank()) {
+            throw new IllegalArgumentException("currency must not be blank");
+        }
+        if (recipientEmail.isBlank()) {
+            throw new IllegalArgumentException("recipientEmail must not be blank");
+        }
+        if (referenceId.isBlank()) {
+            throw new IllegalArgumentException("referenceId must not be blank");
+        }
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount must be greater than 0");
+        }
+    }
+
+    @Override
+    public Topic topic() {
+        return Topic.PAYMENT_CONFIRMED;
+    }
+
+    @Override
+    public JsonNode payload() {
+        final ObjectNode body = JsonNodeFactory.instance.objectNode();
+        body.put("headline", "결제가 완료되었습니다");
+        body.put("message", amount + " " + currency + " 결제가 승인되었습니다.");
+
+        return EmailPayload.builder("결제가 완료되었습니다", body, recipientEmail)
+                .metadata("paymentId", paymentId)
+                .metadata("amount", amount)
+                .metadata("currency", currency)
+                .metadata("confirmedAt", publishedAt.toString())
+                .build();
+    }
+}

--- a/lecture-core/src/main/java/com/liveklass/lecture/domain/id/EnrollmentId.java
+++ b/lecture-core/src/main/java/com/liveklass/lecture/domain/id/EnrollmentId.java
@@ -1,0 +1,9 @@
+package com.liveklass.lecture.domain.id;
+
+import java.util.Objects;
+
+public record EnrollmentId(Long value) {
+    public EnrollmentId {
+        Objects.requireNonNull(value, "value must not be null");
+    }
+}

--- a/lecture-core/src/main/java/com/liveklass/lecture/domain/id/LectureId.java
+++ b/lecture-core/src/main/java/com/liveklass/lecture/domain/id/LectureId.java
@@ -1,0 +1,9 @@
+package com.liveklass.lecture.domain.id;
+
+import java.util.Objects;
+
+public record LectureId(Long value) {
+    public LectureId {
+        Objects.requireNonNull(value, "value must not be null");
+    }
+}

--- a/lecture-core/src/main/java/com/liveklass/lecture/domain/id/UserId.java
+++ b/lecture-core/src/main/java/com/liveklass/lecture/domain/id/UserId.java
@@ -1,0 +1,9 @@
+package com.liveklass.lecture.domain.id;
+
+import java.util.Objects;
+
+public record UserId(Long value) {
+    public UserId {
+        Objects.requireNonNull(value, "value must not be null");
+    }
+}

--- a/lecture-core/src/test/java/com/liveklass/lecture/domain/EnrollmentTest.java
+++ b/lecture-core/src/test/java/com/liveklass/lecture/domain/EnrollmentTest.java
@@ -1,0 +1,81 @@
+package com.liveklass.lecture.domain;
+
+import com.liveklass.lecture.domain.id.LectureId;
+import com.liveklass.lecture.domain.id.UserId;
+import com.liveklass.lecture.fixture.EnrollmentFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag("UNIT_TEST")
+@DisplayName("Enrollment는")
+class EnrollmentTest {
+
+    @Nested
+    @DisplayName("create()는")
+    class Describe_create {
+
+        @Test
+        @DisplayName("기본 상태를 ENROLLED로 생성하고 createdAt과 updatedAt을 동일하게 둔다")
+        void it_creates_enrolled_status_by_default() {
+            // given
+            final LectureId lectureId = new LectureId(10L);
+            final UserId userId = new UserId(100L);
+            final LocalDateTime createdAt = LocalDateTime.of(2026, 4, 1, 9, 0);
+
+            // when
+            final Enrollment enrollment = Enrollment.create(lectureId, userId, createdAt);
+
+            // then
+            assertThat(enrollment.id()).isNull();
+            assertThat(enrollment.lectureId()).isEqualTo(lectureId);
+            assertThat(enrollment.userId()).isEqualTo(userId);
+            assertThat(enrollment.status()).isEqualTo(EnrollmentStatus.ENROLLED);
+            assertThat(enrollment.createdAt()).isEqualTo(createdAt);
+            assertThat(enrollment.updatedAt()).isEqualTo(createdAt);
+        }
+    }
+
+    @Nested
+    @DisplayName("cancel()은")
+    class Describe_cancel {
+
+        @Test
+        @DisplayName("ENROLLED를 CANCELLED로 전이하고 updatedAt을 갱신한다")
+        void it_transitions_to_cancelled() {
+            // given
+            final Enrollment enrollment = EnrollmentFixture.enrolled();
+            final LocalDateTime cancelledAt = LocalDateTime.of(2026, 4, 2, 9, 0);
+
+            // when
+            final Enrollment cancelled = enrollment.cancel(cancelledAt);
+
+            // then
+            assertThat(cancelled.id()).isEqualTo(enrollment.id());
+            assertThat(cancelled.lectureId()).isEqualTo(enrollment.lectureId());
+            assertThat(cancelled.userId()).isEqualTo(enrollment.userId());
+            assertThat(cancelled.status()).isEqualTo(EnrollmentStatus.CANCELLED);
+            assertThat(cancelled.createdAt()).isEqualTo(enrollment.createdAt());
+            assertThat(cancelled.updatedAt()).isEqualTo(cancelledAt);
+        }
+
+        @Test
+        @DisplayName("이미 CANCELLED면 같은 인스턴스를 반환한다")
+        void it_returns_same_instance_when_already_cancelled() {
+            // given
+            final Enrollment cancelledEnrollment = EnrollmentFixture.cancelled(new LectureId(10L), new UserId(100L));
+            final LocalDateTime cancelledAt = LocalDateTime.of(2026, 4, 3, 9, 0);
+
+            // when
+            final Enrollment result = cancelledEnrollment.cancel(cancelledAt);
+
+            // then
+            assertThat(result).isSameAs(cancelledEnrollment);
+        }
+    }
+}

--- a/lecture-core/src/test/java/com/liveklass/lecture/domain/LectureTest.java
+++ b/lecture-core/src/test/java/com/liveklass/lecture/domain/LectureTest.java
@@ -1,0 +1,65 @@
+package com.liveklass.lecture.domain;
+
+import com.liveklass.lecture.domain.id.LectureId;
+import com.liveklass.lecture.fixture.LectureFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+@Tag("UNIT_TEST")
+@DisplayName("Lecture는")
+class LectureTest {
+
+    @Nested
+    @DisplayName("생성자는")
+    class Describe_constructor {
+
+        @Test
+        @DisplayName("유효한 입력이면 필드를 그대로 보존한다")
+        void it_keeps_given_fields() {
+            // given
+            final Lecture lecture = LectureFixture.lecture();
+
+            // when
+            final LectureId id = lecture.id();
+            final String title = lecture.title();
+            final LocalDateTime startAt = lecture.startAt();
+
+            // then
+            assertThat(id.value()).isEqualTo(1L);
+            assertThat(title).isEqualTo("Spring Boot 실전");
+            assertThat(startAt).isEqualTo(LocalDateTime.of(2026, 5, 1, 10, 0));
+        }
+
+        @Test
+        @DisplayName("title이 blank면 예외를 던진다")
+        void it_throws_when_title_is_blank() {
+            // given
+            final String blankTitle = "   ";
+
+            // when & then
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> LectureFixture.lecture(blankTitle))
+                    .withMessageContaining("title");
+        }
+
+        @Test
+        @DisplayName("startAt이 null이면 예외를 던진다")
+        void it_throws_when_start_at_is_null() {
+            // given
+            final LocalDateTime nullStartAt = null;
+
+            // when & then
+            assertThatNullPointerException()
+                    .isThrownBy(() -> LectureFixture.lecture(nullStartAt))
+                    .withMessageContaining("startAt");
+        }
+    }
+}

--- a/lecture-core/src/test/java/com/liveklass/lecture/domain/event/LectureDomainEventTest.java
+++ b/lecture-core/src/test/java/com/liveklass/lecture/domain/event/LectureDomainEventTest.java
@@ -1,0 +1,112 @@
+package com.liveklass.lecture.domain.event;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.liveklass.common.event.Topic;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag("UNIT_TEST")
+@DisplayName("lecture-core 도메인 이벤트는")
+class LectureDomainEventTest {
+
+    @Nested
+    @DisplayName("EnrollmentCompletedEvent는")
+    class Describe_enrollment_completed_event {
+
+        @Test
+        @DisplayName("IN_APP 최소 계약을 만족하는 payload를 반환한다")
+        void it_returns_in_app_payload() {
+            // given
+            final EnrollmentCompletedEvent event = new EnrollmentCompletedEvent(
+                    1L,
+                    10L,
+                    100L,
+                    "Spring Boot 실전",
+                    100L,
+                    "1",
+                    LocalDateTime.of(2026, 4, 24, 10, 0)
+            );
+
+            // when
+            final JsonNode payload = event.payload();
+
+            // then
+            assertThat(event.topic()).isEqualTo(Topic.LECTURE_ENROLLMENT_COMPLETED);
+            assertThat(payload.get("title").asText()).isEqualTo("수강 신청이 완료되었습니다");
+            assertThat(payload.get("body").asText()).contains("Spring Boot 실전");
+            assertThat(payload.get("metadata").get("screen").asText()).isEqualTo("LECTURE_DETAIL");
+            assertThat(payload.get("metadata").get("enrollmentId").asLong()).isEqualTo(1L);
+            assertThat(payload.get("metadata").get("lectureId").asLong()).isEqualTo(10L);
+        }
+    }
+
+    @Nested
+    @DisplayName("EnrollmentCancelledEvent는")
+    class Describe_enrollment_cancelled_event {
+
+        @Test
+        @DisplayName("취소 안내용 IN_APP payload를 반환한다")
+        void it_returns_cancelled_in_app_payload() {
+            // given
+            final EnrollmentCancelledEvent event = new EnrollmentCancelledEvent(
+                    1L,
+                    10L,
+                    100L,
+                    "Spring Boot 실전",
+                    "USER_REQUEST",
+                    100L,
+                    "1",
+                    LocalDateTime.of(2026, 4, 24, 11, 0)
+            );
+
+            // when
+            final JsonNode payload = event.payload();
+
+            // then
+            assertThat(event.topic()).isEqualTo(Topic.LECTURE_ENROLLMENT_CANCELLED);
+            assertThat(payload.get("title").asText()).isEqualTo("수강 신청이 취소되었습니다");
+            assertThat(payload.get("body").asText()).contains("Spring Boot 실전");
+            assertThat(payload.get("metadata").get("severity").asText()).isEqualTo("INFO");
+            assertThat(payload.get("metadata").get("cancelReason").asText()).isEqualTo("USER_REQUEST");
+        }
+    }
+
+    @Nested
+    @DisplayName("PaymentConfirmedEvent는")
+    class Describe_payment_confirmed_event {
+
+        @Test
+        @DisplayName("EMAIL 최소 계약을 만족하는 payload를 반환한다")
+        void it_returns_email_payload() {
+            // given
+            final PaymentConfirmedEvent event = new PaymentConfirmedEvent(
+                    "pay-001",
+                    100L,
+                    1L,
+                    49000L,
+                    "KRW",
+                    "user@example.com",
+                    100L,
+                    "pay-001",
+                    LocalDateTime.of(2026, 4, 24, 12, 0)
+            );
+
+            // when
+            final JsonNode payload = event.payload();
+
+            // then
+            assertThat(event.topic()).isEqualTo(Topic.PAYMENT_CONFIRMED);
+            assertThat(payload.get("subject").asText()).isEqualTo("결제가 완료되었습니다");
+            assertThat(payload.get("body").get("headline").asText()).isEqualTo("결제가 완료되었습니다");
+            assertThat(payload.get("metadata").get("recipientEmail").asText()).isEqualTo("user@example.com");
+            assertThat(payload.get("metadata").get("paymentId").asText()).isEqualTo("pay-001");
+            assertThat(payload.get("metadata").get("amount").asLong()).isEqualTo(49000L);
+        }
+    }
+}

--- a/lecture-core/src/testFixtures/java/com/liveklass/lecture/fixture/EnrollmentFixture.java
+++ b/lecture-core/src/testFixtures/java/com/liveklass/lecture/fixture/EnrollmentFixture.java
@@ -1,0 +1,59 @@
+package com.liveklass.lecture.fixture;
+
+import com.liveklass.lecture.domain.Enrollment;
+import com.liveklass.lecture.domain.EnrollmentStatus;
+import com.liveklass.lecture.domain.id.EnrollmentId;
+import com.liveklass.lecture.domain.id.LectureId;
+import com.liveklass.lecture.domain.id.UserId;
+
+import java.time.LocalDateTime;
+
+public final class EnrollmentFixture {
+
+    private static final EnrollmentId DEFAULT_ID = new EnrollmentId(1L);
+    private static final LectureId DEFAULT_LECTURE_ID = new LectureId(10L);
+    private static final UserId DEFAULT_USER_ID = new UserId(100L);
+    private static final LocalDateTime DEFAULT_CREATED_AT = LocalDateTime.of(2026, 4, 1, 9, 0);
+    private static final LocalDateTime DEFAULT_UPDATED_AT = LocalDateTime.of(2026, 4, 1, 9, 0);
+    private static final LocalDateTime DEFAULT_CANCELLED_AT = LocalDateTime.of(2026, 4, 2, 9, 0);
+
+    private EnrollmentFixture() {
+    }
+
+    public static Enrollment enrolled() {
+        return enrollment(
+                DEFAULT_ID,
+                DEFAULT_LECTURE_ID,
+                DEFAULT_USER_ID,
+                EnrollmentStatus.ENROLLED,
+                DEFAULT_CREATED_AT,
+                DEFAULT_UPDATED_AT
+        );
+    }
+
+    public static Enrollment enrolled(final LectureId lectureId, final UserId userId) {
+        return enrollment(DEFAULT_ID, lectureId, userId, EnrollmentStatus.ENROLLED, DEFAULT_CREATED_AT, DEFAULT_UPDATED_AT);
+    }
+
+    public static Enrollment cancelled(final LectureId lectureId, final UserId userId) {
+        return enrollment(
+                DEFAULT_ID,
+                lectureId,
+                userId,
+                EnrollmentStatus.CANCELLED,
+                DEFAULT_CREATED_AT,
+                DEFAULT_CANCELLED_AT
+        );
+    }
+
+    public static Enrollment enrollment(
+            final EnrollmentId id,
+            final LectureId lectureId,
+            final UserId userId,
+            final EnrollmentStatus status,
+            final LocalDateTime createdAt,
+            final LocalDateTime updatedAt
+    ) {
+        return new Enrollment(id, lectureId, userId, status, createdAt, updatedAt);
+    }
+}

--- a/lecture-core/src/testFixtures/java/com/liveklass/lecture/fixture/LectureFixture.java
+++ b/lecture-core/src/testFixtures/java/com/liveklass/lecture/fixture/LectureFixture.java
@@ -1,0 +1,40 @@
+package com.liveklass.lecture.fixture;
+
+import com.liveklass.lecture.domain.Lecture;
+import com.liveklass.lecture.domain.id.LectureId;
+
+import java.time.LocalDateTime;
+
+public final class LectureFixture {
+
+    private static final LectureId DEFAULT_ID = new LectureId(1L);
+    private static final String DEFAULT_TITLE = "Spring Boot 실전";
+    private static final LocalDateTime DEFAULT_START_AT = LocalDateTime.of(2026, 5, 1, 10, 0);
+    private static final LocalDateTime DEFAULT_CREATED_AT = LocalDateTime.of(2026, 4, 1, 9, 0);
+    private static final LocalDateTime DEFAULT_UPDATED_AT = LocalDateTime.of(2026, 4, 1, 9, 0);
+
+    private LectureFixture() {
+    }
+
+    public static Lecture lecture() {
+        return lecture(DEFAULT_ID, DEFAULT_TITLE, DEFAULT_START_AT, DEFAULT_CREATED_AT, DEFAULT_UPDATED_AT);
+    }
+
+    public static Lecture lecture(final String title) {
+        return lecture(DEFAULT_ID, title, DEFAULT_START_AT, DEFAULT_CREATED_AT, DEFAULT_UPDATED_AT);
+    }
+
+    public static Lecture lecture(final LocalDateTime startAt) {
+        return lecture(DEFAULT_ID, DEFAULT_TITLE, startAt, DEFAULT_CREATED_AT, DEFAULT_UPDATED_AT);
+    }
+
+    public static Lecture lecture(
+            final LectureId id,
+            final String title,
+            final LocalDateTime startAt,
+            final LocalDateTime createdAt,
+            final LocalDateTime updatedAt
+    ) {
+        return new Lecture(id, title, startAt, createdAt, updatedAt);
+    }
+}


### PR DESCRIPTION
## 📌 한눈에 보기

| 구분 | 내용 |
| --- | --- |
| 도메인 모델 | `Lecture`, `Enrollment`, `EnrollmentStatus` 추가 |
| 식별자 | `LectureId`, `EnrollmentId`, `UserId` value object 추가 |
| 이벤트 | 수강 완료/취소, 결제 완료 도메인 이벤트와 payload 정의 |
| 검증 | fixture 및 unit test 추가, `lecture-core` compile/test 통과 |

## 🔧 상세 변경

### 1. 강의/수강 도메인 모델 추가
- `Lecture`, `Enrollment`, `EnrollmentStatus`를 추가해 최소 강의/수강 도메인 모델을 정의
- `Enrollment.create()`와 `Enrollment.cancel()`로 생성과 상태 전이를 도메인 메서드로 정리
- `LectureId`, `EnrollmentId`, `UserId`를 추가해 식별자 값을 value object로 분리

### 2. lecture-core 도메인 이벤트 추가
- `EnrollmentCompletedEvent`, `EnrollmentCancelledEvent`, `PaymentConfirmedEvent`를 추가해 알림 진입용 도메인 이벤트를 정의
- `liveklass-common`의 `InAppPayload`, `EmailPayload` builder를 사용해 각 이벤트의 payload 최소 계약을 맞춤

### 3. fixture와 단위 테스트 추가
- `LectureFixture`, `EnrollmentFixture`를 추가해 테스트 데이터 생성을 표준화
- `LectureTest`, `EnrollmentTest`, `LectureDomainEventTest`를 추가해 도메인 검증, 상태 전이, 이벤트 payload 계약을 검증

## 🧪 검증
- `.\\gradlew.bat :lecture-core:compileJava`
- `.\\gradlew.bat :lecture-core:test`

## ✅ 체크리스트
- [x] 코드 작성 완료
- [x] 단위 테스트 작성
- [x] 로컬 환경 테스트

## 🔗 관련 이슈
- Closes #13

## 🚨 Breaking Changes
- 없음