### PR TITLE
notification-core 도메인 모델 구현

### DIFF
--- a/liveklass-common/build.gradle
+++ b/liveklass-common/build.gradle
@@ -1,10 +1,12 @@
 plugins {
 	id 'java-library'
+	id 'java-test-fixtures'
 }
 
 dependencies {
 	api 'com.fasterxml.jackson.core:jackson-databind'   // DomainEvent.payload() JsonNode 노출
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testFixturesImplementation 'org.assertj:assertj-core'
 }
 
 jar {

--- a/liveklass-common/src/testFixtures/java/com/liveklass/common/test/ExceptionAssertions.java
+++ b/liveklass-common/src/testFixtures/java/com/liveklass/common/test/ExceptionAssertions.java
@@ -1,0 +1,21 @@
+package com.liveklass.common.test;
+
+import com.liveklass.common.error.ExceptionCreator;
+import com.liveklass.common.error.ExceptionInterface;
+import org.assertj.core.api.ThrowableAssert;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ExceptionAssertions {
+
+    private ExceptionAssertions() {}
+
+    public static void assertThatExceptionOfType(
+            final ThrowableAssert.ThrowingCallable callable,
+            final ExceptionInterface expectedException
+    ) {
+        assertThatThrownBy(callable)
+                .isInstanceOf(ExceptionCreator.create(expectedException).getClass())
+                .hasMessage(expectedException.getMessage());
+    }
+}

--- a/notification-core/build.gradle
+++ b/notification-core/build.gradle
@@ -8,6 +8,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testFixturesImplementation project(':liveklass-common')
+	testImplementation(testFixtures(project(':liveklass-common')))
 }
 
 jar {

--- a/notification-core/src/main/java/com/liveklass/notification/domain/DedupKey.java
+++ b/notification-core/src/main/java/com/liveklass/notification/domain/DedupKey.java
@@ -1,0 +1,34 @@
+package com.liveklass.notification.domain;
+
+import com.liveklass.common.error.ExceptionCreator;
+import com.liveklass.common.event.ChannelType;
+import com.liveklass.common.event.Topic;
+import com.liveklass.notification.domain.exception.OutboxException;
+
+import java.util.Objects;
+
+public record DedupKey(String value) {
+
+    private static final int MAX_LENGTH = 512;
+
+    public DedupKey {
+        Objects.requireNonNull(value, "value must not be null");
+        if (value.length() > MAX_LENGTH) {
+            throw ExceptionCreator.create(OutboxException.INVALID_DEDUP_KEY,
+                    "length: " + value.length() + ", max: " + MAX_LENGTH);
+        }
+    }
+
+    public static DedupKey of(
+            final Topic topic,
+            final Long recipientId,
+            final ChannelType channelType,
+            final String referenceId
+    ) {
+        Objects.requireNonNull(topic,       "topic must not be null");
+        Objects.requireNonNull(recipientId, "recipientId must not be null");
+        Objects.requireNonNull(channelType, "channelType must not be null");
+        Objects.requireNonNull(referenceId, "referenceId must not be null");
+        return new DedupKey(topic.name() + ":" + recipientId + ":" + channelType.name() + ":" + referenceId);
+    }
+}

--- a/notification-core/src/main/java/com/liveklass/notification/domain/DomainEventOutbox.java
+++ b/notification-core/src/main/java/com/liveklass/notification/domain/DomainEventOutbox.java
@@ -1,0 +1,136 @@
+package com.liveklass.notification.domain;
+
+import com.liveklass.notification.domain.vo.EventRef;
+import com.liveklass.notification.domain.vo.OutboxId;
+import com.liveklass.notification.domain.vo.ProcessingLock;
+import com.liveklass.notification.domain.vo.SentResult;
+import com.liveklass.common.error.ExceptionCreator;
+import com.liveklass.notification.domain.exception.OutboxException;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Builder(toBuilder = true)
+public record DomainEventOutbox(
+        OutboxId id,
+        String dedupKey,
+        Long recipientId,
+        EventRef eventRef,
+        String payload,
+        ProcessingLock lock,
+        RetryState retryState,
+        LocalDateTime scheduledAt,
+        SentResult sentResult
+) {
+    public DomainEventOutbox {
+        Objects.requireNonNull(dedupKey,   "dedupKey must not be null");
+        Objects.requireNonNull(recipientId,"recipientId must not be null");
+        Objects.requireNonNull(eventRef,   "eventRef must not be null");
+        Objects.requireNonNull(payload,    "payload must not be null");
+        Objects.requireNonNull(lock,       "lock must not be null");
+        Objects.requireNonNull(retryState, "retryState must not be null");
+
+        // SENT ↔ sentResult 불변식
+        if (lock.status() == OutboxStatus.SENT && sentResult == null) {
+            throw ExceptionCreator.create(OutboxException.INVALID_OUTBOX,
+                    "sentResult must not be null when status is SENT");
+        }
+        if (lock.status() != OutboxStatus.SENT && sentResult != null) {
+            throw ExceptionCreator.create(OutboxException.INVALID_OUTBOX,
+                    "sentResult must be null when status is " + lock.status());
+        }
+    }
+
+    public static DomainEventOutbox create(
+            final DedupKey dedupKey,
+            final Long recipientId,
+            final EventRef eventRef,
+            final String payload,
+            final LocalDateTime nextAttemptAt,
+            final LocalDateTime scheduledAt,
+            final int maxAttempts
+    ) {
+        return DomainEventOutbox.builder()
+                .id(new OutboxId(null))
+                .dedupKey(dedupKey.value())
+                .recipientId(recipientId)
+                .eventRef(eventRef)
+                .payload(payload)
+                .lock(ProcessingLock.pending())
+                .retryState(RetryState.initial(maxAttempts, nextAttemptAt))
+                .scheduledAt(scheduledAt)
+                .sentResult(null)
+                .build();
+    }
+
+    /** PENDING → PROCESSING */
+    public DomainEventOutbox claim(final LocalDateTime lockedAt) {
+        lock.status().validateTransitionTo(OutboxStatus.PROCESSING);
+        return toBuilder()
+                .lock(ProcessingLock.processing(Objects.requireNonNull(lockedAt)))
+                .retryState(retryState.increment(retryState.nextAttemptAt()))
+                .build();
+    }
+
+    /** PROCESSING → SENT */
+    public DomainEventOutbox complete(final String providerMessageId, final LocalDateTime sentAt) {
+        lock.status().validateTransitionTo(OutboxStatus.SENT);
+        return toBuilder()
+                .lock(ProcessingLock.sent())
+                .sentResult(SentResult.of(Objects.requireNonNull(sentAt), providerMessageId))
+                .build();
+    }
+
+    /** PROCESSING → PENDING (retry) or DEAD_LETTER */
+    public DomainEventOutbox fail(final String error, final LocalDateTime nextAttemptAt) {
+        if (!retryState.isRetryable()) {
+            return markDeadLetter(error);
+        }
+        lock.status().validateTransitionTo(OutboxStatus.PENDING);
+        return toBuilder()
+                .lock(ProcessingLock.pending())
+                .retryState(retryState.withFailure(error, Objects.requireNonNull(nextAttemptAt)))
+                .build();
+    }
+
+    /** PROCESSING → DEAD_LETTER */
+    public DomainEventOutbox markDeadLetter(final String error) {
+        lock.status().validateTransitionTo(OutboxStatus.DEAD_LETTER);
+        return toBuilder()
+                .lock(ProcessingLock.deadLetter())
+                .retryState(retryState.withFailure(error, retryState.nextAttemptAt()))
+                .build();
+    }
+
+    /** DEAD_LETTER → PENDING (수동 재시도, attempt_count 초기화) */
+    public DomainEventOutbox recover(final LocalDateTime nextAttemptAt) {
+        lock.status().validateTransitionTo(OutboxStatus.PENDING);
+        return toBuilder()
+                .lock(ProcessingLock.pending())
+                .retryState(retryState.reset(Objects.requireNonNull(nextAttemptAt)))
+                .build();
+    }
+
+    /** stuck recovery: PROCESSING → SENT 보정 */
+    public DomainEventOutbox correctToSent(final LocalDateTime sentAt, final String providerMessageId) {
+        lock.status().validateTransitionTo(OutboxStatus.SENT);
+        return toBuilder()
+                .lock(ProcessingLock.sent())
+                .sentResult(SentResult.of(Objects.requireNonNull(sentAt), providerMessageId))
+                .build();
+    }
+
+    /** stuck recovery: PROCESSING → PENDING 회수 */
+    public DomainEventOutbox releaseToRetry(final LocalDateTime nextAttemptAt) {
+        lock.status().validateTransitionTo(OutboxStatus.PENDING);
+        return toBuilder()
+                .lock(ProcessingLock.pending())
+                .retryState(retryState.withFailure(retryState.lastError(), Objects.requireNonNull(nextAttemptAt)))
+                .build();
+    }
+
+    public OutboxStatus status() {
+        return lock.status();
+    }
+}

--- a/notification-core/src/main/java/com/liveklass/notification/domain/Notification.java
+++ b/notification-core/src/main/java/com/liveklass/notification/domain/Notification.java
@@ -1,0 +1,38 @@
+package com.liveklass.notification.domain;
+
+import com.liveklass.common.event.Topic;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public record Notification(
+        Long id,
+        Long outboxId,
+        Long recipientId,
+        Topic topic,
+        String payload,
+        boolean isRead,
+        LocalDateTime createdAt
+) {
+    public Notification {
+        Objects.requireNonNull(outboxId,    "outboxId must not be null");
+        Objects.requireNonNull(recipientId, "recipientId must not be null");
+        Objects.requireNonNull(topic,       "topic must not be null");
+        Objects.requireNonNull(payload,     "payload must not be null");
+        Objects.requireNonNull(createdAt,   "createdAt must not be null");
+    }
+
+    public static Notification create(
+            final Long outboxId,
+            final Long recipientId,
+            final Topic topic,
+            final String payload,
+            final LocalDateTime createdAt
+    ) {
+        return new Notification(null, outboxId, recipientId, topic, payload, false, createdAt);
+    }
+
+    public Notification markRead() {
+        return new Notification(id, outboxId, recipientId, topic, payload, true, createdAt);
+    }
+}

--- a/notification-core/src/main/java/com/liveklass/notification/domain/OutboxStatus.java
+++ b/notification-core/src/main/java/com/liveklass/notification/domain/OutboxStatus.java
@@ -1,0 +1,25 @@
+package com.liveklass.notification.domain;
+
+import com.liveklass.common.error.ExceptionCreator;
+import com.liveklass.notification.domain.exception.OutboxException;
+
+public enum OutboxStatus {
+
+    PENDING,
+    PROCESSING,
+    SENT,
+    DEAD_LETTER;
+
+    public void validateTransitionTo(final OutboxStatus next) {
+        final boolean valid = switch (this) {
+            case PENDING     -> next == PROCESSING;
+            case PROCESSING  -> next == SENT || next == PENDING || next == DEAD_LETTER;
+            case DEAD_LETTER -> next == PENDING;
+            case SENT        -> false;
+        };
+        if (!valid) {
+            throw ExceptionCreator.create(OutboxException.INVALID_STATUS_TRANSITION,
+                    this + " -> " + next);
+        }
+    }
+}

--- a/notification-core/src/main/java/com/liveklass/notification/domain/RetryState.java
+++ b/notification-core/src/main/java/com/liveklass/notification/domain/RetryState.java
@@ -1,0 +1,49 @@
+package com.liveklass.notification.domain;
+
+import com.liveklass.common.error.ExceptionCreator;
+import com.liveklass.notification.domain.exception.OutboxException;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public record RetryState(
+        int attemptCount,
+        int maxAttempts,
+        LocalDateTime nextAttemptAt,
+        String lastError
+) {
+    public RetryState {
+        if (attemptCount < 0) {
+            throw ExceptionCreator.create(OutboxException.INVALID_RETRY_STATE,
+                    "attemptCount must be >= 0, got: " + attemptCount);
+        }
+        if (maxAttempts < 1) {
+            throw ExceptionCreator.create(OutboxException.INVALID_RETRY_STATE,
+                    "maxAttempts must be >= 1, got: " + maxAttempts);
+        }
+        Objects.requireNonNull(nextAttemptAt, "nextAttemptAt must not be null");
+    }
+
+    public static RetryState initial(final int maxAttempts, final LocalDateTime nextAttemptAt) {
+        return new RetryState(0, maxAttempts, nextAttemptAt, null);
+    }
+
+    public boolean isRetryable() {
+        return attemptCount < maxAttempts;
+    }
+
+    public RetryState increment(final LocalDateTime nextAttemptAt) {
+        return new RetryState(attemptCount + 1, maxAttempts,
+                Objects.requireNonNull(nextAttemptAt), lastError);
+    }
+
+    public RetryState withFailure(final String error, final LocalDateTime nextAttemptAt) {
+        return new RetryState(attemptCount, maxAttempts,
+                Objects.requireNonNull(nextAttemptAt), error);
+    }
+
+    public RetryState reset(final LocalDateTime nextAttemptAt) {
+        return new RetryState(0, maxAttempts,
+                Objects.requireNonNull(nextAttemptAt), null);
+    }
+}

--- a/notification-core/src/main/java/com/liveklass/notification/domain/exception/NotificationException.java
+++ b/notification-core/src/main/java/com/liveklass/notification/domain/exception/NotificationException.java
@@ -1,0 +1,25 @@
+package com.liveklass.notification.domain.exception;
+
+import com.liveklass.common.error.ExceptionInterface;
+import com.liveklass.common.error.exception.BadRequestException;
+import com.liveklass.common.error.exception.NotFoundException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationException implements ExceptionInterface {
+
+    INVALID_STATUS_TRANSITION("NOTIFICATION_001", "유효하지 않은 outbox 상태 전이입니다.",     BadRequestException.class),
+    OUTBOX_NOT_FOUND(         "NOTIFICATION_002", "outbox를 찾을 수 없습니다.",               NotFoundException.class),
+    NOTIFICATION_NOT_FOUND(   "NOTIFICATION_003", "알림을 찾을 수 없습니다.",                 NotFoundException.class),
+    INVALID_PAYLOAD(          "NOTIFICATION_004", "채널 payload 최소 계약을 위반했습니다.",    BadRequestException.class),
+    INVALID_DEDUP_KEY(        "NOTIFICATION_005", "DedupKey가 허용 길이를 초과했습니다.",      BadRequestException.class),
+    INVALID_RETRY_STATE(      "NOTIFICATION_006", "RetryState 값이 유효하지 않습니다.",       BadRequestException.class),
+    INVALID_PROCESSING_LOCK(  "NOTIFICATION_007", "ProcessingLock 불변식을 위반했습니다.",    BadRequestException.class),
+    INVALID_OUTBOX(           "NOTIFICATION_008", "DomainEventOutbox 불변식을 위반했습니다.", BadRequestException.class);
+
+    private final String errorCode;
+    private final String message;
+    private final Class<? extends RuntimeException> aClass;
+}

--- a/notification-core/src/main/java/com/liveklass/notification/domain/exception/OutboxException.java
+++ b/notification-core/src/main/java/com/liveklass/notification/domain/exception/OutboxException.java
@@ -1,0 +1,23 @@
+package com.liveklass.notification.domain.exception;
+
+import com.liveklass.common.error.ExceptionInterface;
+import com.liveklass.common.error.exception.BadRequestException;
+import com.liveklass.common.error.exception.NotFoundException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum OutboxException implements ExceptionInterface {
+
+    INVALID_STATUS_TRANSITION("OUTBOX_001", "유효하지 않은 outbox 상태 전이입니다.",        BadRequestException.class),
+    OUTBOX_NOT_FOUND(         "OUTBOX_002", "outbox를 찾을 수 없습니다.",                  NotFoundException.class),
+    INVALID_DEDUP_KEY(        "OUTBOX_003", "DedupKey가 허용 길이를 초과했습니다.",         BadRequestException.class),
+    INVALID_RETRY_STATE(      "OUTBOX_004", "RetryState 값이 유효하지 않습니다.",          BadRequestException.class),
+    INVALID_PROCESSING_LOCK(  "OUTBOX_005", "ProcessingLock 불변식을 위반했습니다.",       BadRequestException.class),
+    INVALID_OUTBOX(           "OUTBOX_006", "DomainEventOutbox 불변식을 위반했습니다.",    BadRequestException.class);
+
+    private final String errorCode;
+    private final String message;
+    private final Class<? extends RuntimeException> aClass;
+}

--- a/notification-core/src/main/java/com/liveklass/notification/domain/vo/EventRef.java
+++ b/notification-core/src/main/java/com/liveklass/notification/domain/vo/EventRef.java
@@ -1,0 +1,18 @@
+package com.liveklass.notification.domain.vo;
+
+import com.liveklass.common.event.ChannelType;
+import com.liveklass.common.event.Topic;
+
+import java.util.Objects;
+
+public record EventRef(
+        Topic topic,
+        ChannelType channelType,
+        String referenceId
+) {
+    public EventRef {
+        Objects.requireNonNull(topic,       "topic must not be null");
+        Objects.requireNonNull(channelType, "channelType must not be null");
+        Objects.requireNonNull(referenceId, "referenceId must not be null");
+    }
+}

--- a/notification-core/src/main/java/com/liveklass/notification/domain/vo/OutboxId.java
+++ b/notification-core/src/main/java/com/liveklass/notification/domain/vo/OutboxId.java
@@ -1,0 +1,19 @@
+package com.liveklass.notification.domain.vo;
+
+public record OutboxId(Long id) {
+
+    public OutboxId {
+        if (id != null && id <= 0) {
+            throw new IllegalArgumentException("OutboxId must be positive: " + id);
+        }
+    }
+
+    public static OutboxId of(final Long id) {
+        return new OutboxId(id);
+    }
+
+    @Override
+    public String toString() {
+        return id == null ? "null" : String.valueOf(id);
+    }
+}

--- a/notification-core/src/main/java/com/liveklass/notification/domain/vo/ProcessingLock.java
+++ b/notification-core/src/main/java/com/liveklass/notification/domain/vo/ProcessingLock.java
@@ -1,0 +1,29 @@
+package com.liveklass.notification.domain.vo;
+
+import com.liveklass.common.error.ExceptionCreator;
+import com.liveklass.notification.domain.OutboxStatus;
+import com.liveklass.notification.domain.exception.OutboxException;
+
+import java.time.LocalDateTime;
+
+public record ProcessingLock(
+        OutboxStatus status,
+        LocalDateTime lockedAt
+) {
+    public ProcessingLock {
+        if (status == null) throw new NullPointerException("status must not be null");
+        if (status == OutboxStatus.PROCESSING && lockedAt == null) {
+            throw ExceptionCreator.create(OutboxException.INVALID_PROCESSING_LOCK,
+                    "lockedAt must not be null when status is PROCESSING");
+        }
+        if (status != OutboxStatus.PROCESSING && lockedAt != null) {
+            throw ExceptionCreator.create(OutboxException.INVALID_PROCESSING_LOCK,
+                    "lockedAt must be null when status is " + status);
+        }
+    }
+
+    public static ProcessingLock pending()                             { return new ProcessingLock(OutboxStatus.PENDING, null); }
+    public static ProcessingLock processing(final LocalDateTime lockedAt) { return new ProcessingLock(OutboxStatus.PROCESSING, lockedAt); }
+    public static ProcessingLock sent()                                { return new ProcessingLock(OutboxStatus.SENT, null); }
+    public static ProcessingLock deadLetter()                          { return new ProcessingLock(OutboxStatus.DEAD_LETTER, null); }
+}

--- a/notification-core/src/main/java/com/liveklass/notification/domain/vo/SentResult.java
+++ b/notification-core/src/main/java/com/liveklass/notification/domain/vo/SentResult.java
@@ -1,0 +1,22 @@
+package com.liveklass.notification.domain.vo;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+/**
+ * 발송 완료 결과. SENT 상태일 때만 non-null이다.
+ * providerMessageId는 provider가 발송 성공 후 반환하는 ID다.
+ * stuck recovery에서 "실제 발송 여부" 확인 및 멱등성 키 조회에 활용한다.
+ */
+public record SentResult(
+        LocalDateTime sentAt,
+        String providerMessageId
+) {
+    public SentResult {
+        Objects.requireNonNull(sentAt, "sentAt must not be null");
+    }
+
+    public static SentResult of(final LocalDateTime sentAt, final String providerMessageId) {
+        return new SentResult(sentAt, providerMessageId);
+    }
+}

--- a/notification-core/src/test/java/com/liveklass/notification/domain/DedupKeyTest.java
+++ b/notification-core/src/test/java/com/liveklass/notification/domain/DedupKeyTest.java
@@ -1,0 +1,102 @@
+package com.liveklass.notification.domain;
+
+import com.liveklass.common.event.ChannelType;
+import com.liveklass.common.event.Topic;
+import com.liveklass.common.test.ExceptionAssertions;
+import com.liveklass.notification.domain.exception.OutboxException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+@Tag("UNIT_TEST")
+@DisplayName("DedupKey는")
+class DedupKeyTest {
+
+    @Nested
+    @DisplayName("of()는")
+    class Describe_of {
+
+        @Test
+        @DisplayName("{topic}:{recipientId}:{channelType}:{referenceId} 포맷으로 value를 반환한다")
+        void it_returns_formatted_value() {
+            // given
+            final Topic topic = Topic.PAYMENT_CONFIRMED;
+            final Long recipientId = 42L;
+            final ChannelType channelType = ChannelType.EMAIL;
+            final String referenceId = "pay-001";
+
+            // when
+            final DedupKey dedupKey = DedupKey.of(topic, recipientId, channelType, referenceId);
+
+            // then
+            assertThat(dedupKey.value()).isEqualTo("PAYMENT_CONFIRMED:42:EMAIL:pay-001");
+        }
+
+        @Test
+        @DisplayName("동일한 입력으로 생성한 두 DedupKey는 equals가 true다")
+        void it_equals_same_inputs() {
+            // given
+            final Topic topic = Topic.LECTURE_ENROLLMENT_COMPLETED;
+            final Long recipientId = 1L;
+            final ChannelType channelType = ChannelType.IN_APP;
+            final String referenceId = "enroll-100";
+
+            // when
+            final DedupKey key1 = DedupKey.of(topic, recipientId, channelType, referenceId);
+            final DedupKey key2 = DedupKey.of(topic, recipientId, channelType, referenceId);
+
+            // then
+            assertThat(key1).isEqualTo(key2);
+            assertThat(key1.hashCode()).isEqualTo(key2.hashCode());
+        }
+
+        @Test
+        @DisplayName("512자를 초과하면 INVALID_DEDUP_KEY 예외를 던진다")
+        void it_throws_when_value_exceeds_max_length() {
+            // given
+            final String longReferenceId = "x".repeat(512);
+
+            // when & then
+            ExceptionAssertions.assertThatExceptionOfType(
+                    () -> DedupKey.of(Topic.PAYMENT_CONFIRMED, 1L, ChannelType.EMAIL, longReferenceId),
+                    OutboxException.INVALID_DEDUP_KEY
+            );
+        }
+
+        @Test
+        @DisplayName("topic이 null이면 NPE를 던진다")
+        void it_throws_when_topic_is_null() {
+            assertThatNullPointerException()
+                    .isThrownBy(() -> DedupKey.of(null, 1L, ChannelType.EMAIL, "ref-1"))
+                    .withMessageContaining("topic");
+        }
+
+        @Test
+        @DisplayName("recipientId가 null이면 NPE를 던진다")
+        void it_throws_when_recipient_id_is_null() {
+            assertThatNullPointerException()
+                    .isThrownBy(() -> DedupKey.of(Topic.PAYMENT_CONFIRMED, null, ChannelType.EMAIL, "ref-1"))
+                    .withMessageContaining("recipientId");
+        }
+
+        @Test
+        @DisplayName("channelType이 null이면 NPE를 던진다")
+        void it_throws_when_channel_type_is_null() {
+            assertThatNullPointerException()
+                    .isThrownBy(() -> DedupKey.of(Topic.PAYMENT_CONFIRMED, 1L, null, "ref-1"))
+                    .withMessageContaining("channelType");
+        }
+
+        @Test
+        @DisplayName("referenceId가 null이면 NPE를 던진다")
+        void it_throws_when_reference_id_is_null() {
+            assertThatNullPointerException()
+                    .isThrownBy(() -> DedupKey.of(Topic.PAYMENT_CONFIRMED, 1L, ChannelType.EMAIL, null))
+                    .withMessageContaining("referenceId");
+        }
+    }
+}

--- a/notification-core/src/test/java/com/liveklass/notification/domain/DomainEventOutboxTest.java
+++ b/notification-core/src/test/java/com/liveklass/notification/domain/DomainEventOutboxTest.java
@@ -1,0 +1,212 @@
+package com.liveklass.notification.domain;
+
+import com.liveklass.common.error.exception.BadRequestException;
+import com.liveklass.notification.domain.vo.ProcessingLock;
+import com.liveklass.notification.domain.vo.SentResult;
+import com.liveklass.notification.fixture.DomainEventOutboxFixture;
+import com.liveklass.notification.fixture.NotificationFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+@Tag("UNIT_TEST")
+@DisplayName("DomainEventOutbox는")
+class DomainEventOutboxTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 4, 24, 12, 0);
+
+    @Nested
+    @DisplayName("create()는")
+    class Describe_create {
+
+        @Test
+        @DisplayName("초기 상태는 PENDING이고 sentResult는 null이다")
+        void it_creates_with_pending_status_and_no_sent_result() {
+            // given & when
+            final DomainEventOutbox outbox = DomainEventOutboxFixture.pending();
+
+            // then
+            assertThat(outbox.status()).isEqualTo(OutboxStatus.PENDING);
+            assertThat(outbox.retryState().attemptCount()).isZero();
+            assertThat(outbox.sentResult()).isNull();
+            assertThat(outbox.lock().lockedAt()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("claim()은")
+    class Describe_claim {
+
+        @Test
+        @DisplayName("PENDING → PROCESSING으로 전이하고 lock과 attemptCount가 갱신된다")
+        void it_transitions_to_processing() {
+            // given
+            final DomainEventOutbox outbox = DomainEventOutboxFixture.pending();
+            final LocalDateTime lockedAt = NOW;
+
+            // when
+            final DomainEventOutbox claimed = outbox.claim(lockedAt);
+
+            // then
+            assertThat(claimed.status()).isEqualTo(OutboxStatus.PROCESSING);
+            assertThat(claimed.lock().lockedAt()).isEqualTo(lockedAt);
+            assertThat(claimed.retryState().attemptCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("PROCESSING 상태에서 다시 claim()하면 BadRequestException을 던진다")
+        void it_throws_when_already_processing() {
+            // given
+            final DomainEventOutbox processing = DomainEventOutboxFixture.processing();
+
+            // when & then
+            assertThatExceptionOfType(BadRequestException.class)
+                    .isThrownBy(() -> processing.claim(NOW));
+        }
+    }
+
+    @Nested
+    @DisplayName("complete()는")
+    class Describe_complete {
+
+        @Test
+        @DisplayName("PROCESSING → SENT로 전이하고 sentResult가 채워진다")
+        void it_transitions_to_sent_with_sent_result() {
+            // given
+            final DomainEventOutbox processing = DomainEventOutboxFixture.processing();
+            final String providerMessageId = "msg-xyz";
+            final LocalDateTime sentAt = NOW.plusSeconds(2);
+
+            // when
+            final DomainEventOutbox completed = processing.complete(providerMessageId, sentAt);
+
+            // then
+            assertThat(completed.status()).isEqualTo(OutboxStatus.SENT);
+            assertThat(completed.sentResult().sentAt()).isEqualTo(sentAt);
+            assertThat(completed.sentResult().providerMessageId()).isEqualTo(providerMessageId);
+            assertThat(completed.lock().lockedAt()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("fail()은")
+    class Describe_fail {
+
+        @Test
+        @DisplayName("재시도 가능하면 PENDING으로 돌아가고 lastError가 기록된다")
+        void it_returns_to_pending_with_error_when_retryable() {
+            // given
+            final DomainEventOutbox processing = DomainEventOutboxFixture.processing();
+            final String error = "connection timeout";
+            final LocalDateTime nextAttemptAt = NOW.plusMinutes(1);
+
+            // when
+            final DomainEventOutbox failed = processing.fail(error, nextAttemptAt);
+
+            // then
+            assertThat(failed.status()).isEqualTo(OutboxStatus.PENDING);
+            assertThat(failed.retryState().lastError()).isEqualTo(error);
+            assertThat(failed.retryState().nextAttemptAt()).isEqualTo(nextAttemptAt);
+            assertThat(failed.lock().lockedAt()).isNull();
+        }
+
+        @Test
+        @DisplayName("maxAttempts 소진 시 DEAD_LETTER로 전이하고 sentResult는 null이다")
+        void it_transitions_to_dead_letter_when_attempts_exhausted() {
+            // given
+            final DomainEventOutbox outbox = DomainEventOutboxFixture.pendingWithMaxAttempts(1, "pay-002");
+            final DomainEventOutbox processing = outbox.claim(NOW);
+            final String error = "fatal error";
+
+            // when
+            final DomainEventOutbox deadLetter = processing.fail(error, NOW.plusMinutes(1));
+
+            // then
+            assertThat(deadLetter.status()).isEqualTo(OutboxStatus.DEAD_LETTER);
+            assertThat(deadLetter.retryState().lastError()).isEqualTo(error);
+            assertThat(deadLetter.sentResult()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("recover()는")
+    class Describe_recover {
+
+        @Test
+        @DisplayName("DEAD_LETTER → PENDING으로 전이하고 attemptCount가 0으로 초기화된다")
+        void it_resets_to_pending_with_zero_attempt_count() {
+            // given
+            final DomainEventOutbox deadLetter = DomainEventOutboxFixture.deadLetter("pay-003");
+            final LocalDateTime retryAt = NOW.plusHours(1);
+
+            // when
+            final DomainEventOutbox recovered = deadLetter.recover(retryAt);
+
+            // then
+            assertThat(recovered.status()).isEqualTo(OutboxStatus.PENDING);
+            assertThat(recovered.retryState().attemptCount()).isZero();
+            assertThat(recovered.retryState().nextAttemptAt()).isEqualTo(retryAt);
+            assertThat(recovered.retryState().lastError()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("SENT ↔ sentResult 불변식은")
+    class Describe_sent_result_invariant {
+
+        @Test
+        @DisplayName("SENT 상태가 되면 sentResult가 반드시 채워진다")
+        void it_always_has_sent_result_when_sent() {
+            // given
+            final DomainEventOutbox sent = DomainEventOutboxFixture.sent();
+
+            // when & then
+            assertThat(sent.status()).isEqualTo(OutboxStatus.SENT);
+            assertThat(sent.sentResult()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("PENDING/PROCESSING/DEAD_LETTER 상태에서는 sentResult가 null이다")
+        void it_has_no_sent_result_when_not_sent() {
+            assertThat(DomainEventOutboxFixture.pending().sentResult()).isNull();
+            assertThat(DomainEventOutboxFixture.processing().sentResult()).isNull();
+            assertThat(DomainEventOutboxFixture.deadLetter("pay-x").sentResult()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("Notification 엔티티는")
+    class Describe_notification {
+
+        @Test
+        @DisplayName("초기 isRead는 false다")
+        void it_creates_unread() {
+            // given & when
+            final Notification notification = NotificationFixture.unread();
+
+            // then
+            assertThat(notification.isRead()).isFalse();
+        }
+
+        @Test
+        @DisplayName("markRead()는 멱등하다")
+        void it_marks_read_idempotently() {
+            // given
+            final Notification notification = NotificationFixture.unread();
+
+            // when
+            final Notification read1 = notification.markRead();
+            final Notification read2 = read1.markRead();
+
+            // then
+            assertThat(read1.isRead()).isTrue();
+            assertThat(read2.isRead()).isTrue();
+        }
+    }
+}

--- a/notification-core/src/test/java/com/liveklass/notification/domain/OutboxStatusTest.java
+++ b/notification-core/src/test/java/com/liveklass/notification/domain/OutboxStatusTest.java
@@ -1,0 +1,98 @@
+package com.liveklass.notification.domain;
+
+import com.liveklass.common.test.ExceptionAssertions;
+import com.liveklass.notification.domain.exception.OutboxException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@Tag("UNIT_TEST")
+@DisplayName("OutboxStatus 전이 규칙은")
+class OutboxStatusTest {
+
+    @Nested
+    @DisplayName("유효한 전이는")
+    class Describe_valid_transitions {
+
+        @Test
+        @DisplayName("PENDING → PROCESSING을 허용한다")
+        void it_allows_pending_to_processing() {
+            assertThatCode(() -> OutboxStatus.PENDING.validateTransitionTo(OutboxStatus.PROCESSING))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("PROCESSING → SENT를 허용한다")
+        void it_allows_processing_to_sent() {
+            assertThatCode(() -> OutboxStatus.PROCESSING.validateTransitionTo(OutboxStatus.SENT))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("PROCESSING → PENDING을 허용한다 (재시도)")
+        void it_allows_processing_to_pending() {
+            assertThatCode(() -> OutboxStatus.PROCESSING.validateTransitionTo(OutboxStatus.PENDING))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("PROCESSING → DEAD_LETTER를 허용한다")
+        void it_allows_processing_to_dead_letter() {
+            assertThatCode(() -> OutboxStatus.PROCESSING.validateTransitionTo(OutboxStatus.DEAD_LETTER))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("DEAD_LETTER → PENDING을 허용한다 (수동 재시도)")
+        void it_allows_dead_letter_to_pending() {
+            assertThatCode(() -> OutboxStatus.DEAD_LETTER.validateTransitionTo(OutboxStatus.PENDING))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("유효하지 않은 전이는")
+    class Describe_invalid_transitions {
+
+        @Test
+        @DisplayName("SENT → 어떤 상태로도 전이하면 INVALID_STATUS_TRANSITION 예외를 던진다")
+        void it_throws_when_transitioning_from_sent() {
+            for (final OutboxStatus next : OutboxStatus.values()) {
+                ExceptionAssertions.assertThatExceptionOfType(
+                        () -> OutboxStatus.SENT.validateTransitionTo(next),
+                        OutboxException.INVALID_STATUS_TRANSITION
+                );
+            }
+        }
+
+        @Test
+        @DisplayName("PENDING → SENT 직접 전이는 INVALID_STATUS_TRANSITION 예외를 던진다")
+        void it_throws_when_pending_to_sent() {
+            ExceptionAssertions.assertThatExceptionOfType(
+                    () -> OutboxStatus.PENDING.validateTransitionTo(OutboxStatus.SENT),
+                    OutboxException.INVALID_STATUS_TRANSITION
+            );
+        }
+
+        @Test
+        @DisplayName("PENDING → DEAD_LETTER 직접 전이는 INVALID_STATUS_TRANSITION 예외를 던진다")
+        void it_throws_when_pending_to_dead_letter() {
+            ExceptionAssertions.assertThatExceptionOfType(
+                    () -> OutboxStatus.PENDING.validateTransitionTo(OutboxStatus.DEAD_LETTER),
+                    OutboxException.INVALID_STATUS_TRANSITION
+            );
+        }
+
+        @Test
+        @DisplayName("DEAD_LETTER → SENT 직접 전이는 INVALID_STATUS_TRANSITION 예외를 던진다")
+        void it_throws_when_dead_letter_to_sent() {
+            ExceptionAssertions.assertThatExceptionOfType(
+                    () -> OutboxStatus.DEAD_LETTER.validateTransitionTo(OutboxStatus.SENT),
+                    OutboxException.INVALID_STATUS_TRANSITION
+            );
+        }
+    }
+}

--- a/notification-core/src/test/java/com/liveklass/notification/domain/RetryStateTest.java
+++ b/notification-core/src/test/java/com/liveklass/notification/domain/RetryStateTest.java
@@ -1,0 +1,152 @@
+package com.liveklass.notification.domain;
+
+import com.liveklass.common.test.ExceptionAssertions;
+import com.liveklass.notification.domain.exception.OutboxException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+@Tag("UNIT_TEST")
+@DisplayName("RetryState는")
+class RetryStateTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 4, 24, 12, 0);
+
+    @Nested
+    @DisplayName("initial()은")
+    class Describe_initial {
+
+        @Test
+        @DisplayName("attemptCount=0, lastError=null로 초기화된다")
+        void it_initializes_with_zero_attempt_and_no_error() {
+            // given
+            final int maxAttempts = 3;
+
+            // when
+            final RetryState state = RetryState.initial(maxAttempts, NOW);
+
+            // then
+            assertThat(state.attemptCount()).isZero();
+            assertThat(state.maxAttempts()).isEqualTo(maxAttempts);
+            assertThat(state.nextAttemptAt()).isEqualTo(NOW);
+            assertThat(state.lastError()).isNull();
+        }
+
+        @Test
+        @DisplayName("maxAttempts가 0 이하면 INVALID_RETRY_STATE 예외를 던진다")
+        void it_throws_when_max_attempts_is_zero_or_less() {
+            ExceptionAssertions.assertThatExceptionOfType(
+                    () -> RetryState.initial(0, NOW),
+                    OutboxException.INVALID_RETRY_STATE
+            );
+            ExceptionAssertions.assertThatExceptionOfType(
+                    () -> RetryState.initial(-1, NOW),
+                    OutboxException.INVALID_RETRY_STATE
+            );
+        }
+
+        @Test
+        @DisplayName("nextAttemptAt이 null이면 NPE를 던진다")
+        void it_throws_when_next_attempt_at_is_null() {
+            assertThatNullPointerException()
+                    .isThrownBy(() -> RetryState.initial(3, null))
+                    .withMessageContaining("nextAttemptAt");
+        }
+    }
+
+    @Nested
+    @DisplayName("isRetryable()은")
+    class Describe_is_retryable {
+
+        @Test
+        @DisplayName("attemptCount < maxAttempts이면 true를 반환한다")
+        void it_returns_true_when_attempt_count_less_than_max() {
+            // given
+            final RetryState state = RetryState.initial(3, NOW);
+
+            // when & then
+            assertThat(state.isRetryable()).isTrue();
+        }
+
+        @Test
+        @DisplayName("attemptCount == maxAttempts이면 false를 반환한다")
+        void it_returns_false_when_attempt_count_equals_max() {
+            // given
+            final RetryState state = new RetryState(3, 3, NOW, null);
+
+            // when & then
+            assertThat(state.isRetryable()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("increment()은")
+    class Describe_increment {
+
+        @Test
+        @DisplayName("attemptCount를 1 증가시키고 nextAttemptAt을 갱신한다")
+        void it_increments_attempt_count_and_updates_next_attempt_at() {
+            // given
+            final RetryState state = RetryState.initial(3, NOW);
+            final LocalDateTime nextAttemptAt = NOW.plusMinutes(5);
+
+            // when
+            final RetryState incremented = state.increment(nextAttemptAt);
+
+            // then
+            assertThat(incremented.attemptCount()).isEqualTo(1);
+            assertThat(incremented.nextAttemptAt()).isEqualTo(nextAttemptAt);
+            assertThat(incremented.maxAttempts()).isEqualTo(state.maxAttempts());
+        }
+    }
+
+    @Nested
+    @DisplayName("withFailure()은")
+    class Describe_with_failure {
+
+        @Test
+        @DisplayName("에러 메시지와 nextAttemptAt을 기록한다")
+        void it_records_error_and_next_attempt_at() {
+            // given
+            final RetryState state = RetryState.initial(3, NOW);
+            final String error = "connection timeout";
+            final LocalDateTime nextAttemptAt = NOW.plusMinutes(2);
+
+            // when
+            final RetryState failed = state.withFailure(error, nextAttemptAt);
+
+            // then
+            assertThat(failed.lastError()).isEqualTo(error);
+            assertThat(failed.nextAttemptAt()).isEqualTo(nextAttemptAt);
+            assertThat(failed.attemptCount()).isEqualTo(state.attemptCount());
+        }
+    }
+
+    @Nested
+    @DisplayName("reset()은")
+    class Describe_reset {
+
+        @Test
+        @DisplayName("attemptCount를 0으로 초기화하고 lastError를 null로 만든다")
+        void it_resets_attempt_count_and_clears_error() {
+            // given
+            final RetryState exhausted = new RetryState(3, 3, NOW, "fatal error");
+            final LocalDateTime retryAt = NOW.plusHours(1);
+
+            // when
+            final RetryState reset = exhausted.reset(retryAt);
+
+            // then
+            assertThat(reset.attemptCount()).isZero();
+            assertThat(reset.lastError()).isNull();
+            assertThat(reset.nextAttemptAt()).isEqualTo(retryAt);
+            assertThat(reset.maxAttempts()).isEqualTo(exhausted.maxAttempts());
+        }
+    }
+}

--- a/notification-core/src/test/java/com/liveklass/notification/domain/vo/EventRefTest.java
+++ b/notification-core/src/test/java/com/liveklass/notification/domain/vo/EventRefTest.java
@@ -1,0 +1,62 @@
+package com.liveklass.notification.domain.vo;
+
+import com.liveklass.common.event.ChannelType;
+import com.liveklass.common.event.Topic;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+@Tag("UNIT_TEST")
+@DisplayName("EventRef는")
+class EventRefTest {
+
+    @Nested
+    @DisplayName("생성은")
+    class Describe_create {
+
+        @Test
+        @DisplayName("topic, channelType, referenceId를 그대로 보유한다")
+        void it_holds_all_fields() {
+            // given
+            final Topic topic = Topic.PAYMENT_CONFIRMED;
+            final ChannelType channelType = ChannelType.EMAIL;
+            final String referenceId = "pay-001";
+
+            // when
+            final EventRef eventRef = new EventRef(topic, channelType, referenceId);
+
+            // then
+            assertThat(eventRef.topic()).isEqualTo(topic);
+            assertThat(eventRef.channelType()).isEqualTo(channelType);
+            assertThat(eventRef.referenceId()).isEqualTo(referenceId);
+        }
+
+        @Test
+        @DisplayName("topic이 null이면 NPE를 던진다")
+        void it_throws_when_topic_is_null() {
+            assertThatNullPointerException()
+                    .isThrownBy(() -> new EventRef(null, ChannelType.EMAIL, "ref"))
+                    .withMessageContaining("topic");
+        }
+
+        @Test
+        @DisplayName("channelType이 null이면 NPE를 던진다")
+        void it_throws_when_channel_type_is_null() {
+            assertThatNullPointerException()
+                    .isThrownBy(() -> new EventRef(Topic.PAYMENT_CONFIRMED, null, "ref"))
+                    .withMessageContaining("channelType");
+        }
+
+        @Test
+        @DisplayName("referenceId가 null이면 NPE를 던진다")
+        void it_throws_when_reference_id_is_null() {
+            assertThatNullPointerException()
+                    .isThrownBy(() -> new EventRef(Topic.PAYMENT_CONFIRMED, ChannelType.EMAIL, null))
+                    .withMessageContaining("referenceId");
+        }
+    }
+}

--- a/notification-core/src/test/java/com/liveklass/notification/domain/vo/OutboxIdTest.java
+++ b/notification-core/src/test/java/com/liveklass/notification/domain/vo/OutboxIdTest.java
@@ -1,0 +1,51 @@
+package com.liveklass.notification.domain.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+@Tag("UNIT_TEST")
+@DisplayName("OutboxId는")
+class OutboxIdTest {
+
+    @Nested
+    @DisplayName("of()는")
+    class Describe_of {
+
+        @Test
+        @DisplayName("양수 id를 그대로 보유한다")
+        void it_holds_positive_id() {
+            // given
+            final Long id = 42L;
+
+            // when
+            final OutboxId outboxId = OutboxId.of(id);
+
+            // then
+            assertThat(outboxId.id()).isEqualTo(id);
+        }
+
+        @Test
+        @DisplayName("null id는 허용한다 (DB 저장 전 미할당 상태)")
+        void it_allows_null_id() {
+            // given & when
+            final OutboxId outboxId = OutboxId.of(null);
+
+            // then
+            assertThat(outboxId.id()).isNull();
+        }
+
+        @Test
+        @DisplayName("0 이하 id는 예외를 던진다")
+        void it_throws_when_id_is_non_positive() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> OutboxId.of(0L));
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> OutboxId.of(-1L));
+        }
+    }
+}

--- a/notification-core/src/test/java/com/liveklass/notification/domain/vo/ProcessingLockTest.java
+++ b/notification-core/src/test/java/com/liveklass/notification/domain/vo/ProcessingLockTest.java
@@ -1,0 +1,95 @@
+package com.liveklass.notification.domain.vo;
+
+import com.liveklass.common.test.ExceptionAssertions;
+import com.liveklass.notification.domain.OutboxStatus;
+import com.liveklass.notification.domain.exception.OutboxException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag("UNIT_TEST")
+@DisplayName("ProcessingLock는")
+class ProcessingLockTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 4, 24, 12, 0);
+
+    @Nested
+    @DisplayName("불변식은")
+    class Describe_invariant {
+
+        @Test
+        @DisplayName("PROCESSING이면 lockedAt이 반드시 있어야 한다")
+        void it_requires_locked_at_when_processing() {
+            ExceptionAssertions.assertThatExceptionOfType(
+                    () -> new ProcessingLock(OutboxStatus.PROCESSING, null),
+                    OutboxException.INVALID_PROCESSING_LOCK
+            );
+        }
+
+        @Test
+        @DisplayName("PROCESSING이 아니면 lockedAt이 없어야 한다")
+        void it_requires_no_locked_at_when_not_processing() {
+            ExceptionAssertions.assertThatExceptionOfType(
+                    () -> new ProcessingLock(OutboxStatus.PENDING, NOW),
+                    OutboxException.INVALID_PROCESSING_LOCK
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("팩토리 메서드는")
+    class Describe_factories {
+
+        @Test
+        @DisplayName("pending()은 PENDING + lockedAt null을 반환한다")
+        void it_creates_pending() {
+            // given & when
+            final ProcessingLock lock = ProcessingLock.pending();
+
+            // then
+            assertThat(lock.status()).isEqualTo(OutboxStatus.PENDING);
+            assertThat(lock.lockedAt()).isNull();
+        }
+
+        @Test
+        @DisplayName("processing(lockedAt)은 PROCESSING + lockedAt을 반환한다")
+        void it_creates_processing() {
+            // given
+            final LocalDateTime lockedAt = NOW;
+
+            // when
+            final ProcessingLock lock = ProcessingLock.processing(lockedAt);
+
+            // then
+            assertThat(lock.status()).isEqualTo(OutboxStatus.PROCESSING);
+            assertThat(lock.lockedAt()).isEqualTo(lockedAt);
+        }
+
+        @Test
+        @DisplayName("sent()는 SENT + lockedAt null을 반환한다")
+        void it_creates_sent() {
+            // given & when
+            final ProcessingLock lock = ProcessingLock.sent();
+
+            // then
+            assertThat(lock.status()).isEqualTo(OutboxStatus.SENT);
+            assertThat(lock.lockedAt()).isNull();
+        }
+
+        @Test
+        @DisplayName("deadLetter()는 DEAD_LETTER + lockedAt null을 반환한다")
+        void it_creates_dead_letter() {
+            // given & when
+            final ProcessingLock lock = ProcessingLock.deadLetter();
+
+            // then
+            assertThat(lock.status()).isEqualTo(OutboxStatus.DEAD_LETTER);
+            assertThat(lock.lockedAt()).isNull();
+        }
+    }
+}

--- a/notification-core/src/test/java/com/liveklass/notification/domain/vo/SentResultTest.java
+++ b/notification-core/src/test/java/com/liveklass/notification/domain/vo/SentResultTest.java
@@ -1,0 +1,55 @@
+package com.liveklass.notification.domain.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+@Tag("UNIT_TEST")
+@DisplayName("SentResult는")
+class SentResultTest {
+
+    private static final LocalDateTime SENT_AT = LocalDateTime.of(2026, 4, 24, 12, 0);
+
+    @Nested
+    @DisplayName("of()는")
+    class Describe_of {
+
+        @Test
+        @DisplayName("sentAt과 providerMessageId를 그대로 보유한다")
+        void it_holds_sent_at_and_provider_message_id() {
+            // given
+            final String providerMessageId = "msg-abc123";
+
+            // when
+            final SentResult result = SentResult.of(SENT_AT, providerMessageId);
+
+            // then
+            assertThat(result.sentAt()).isEqualTo(SENT_AT);
+            assertThat(result.providerMessageId()).isEqualTo(providerMessageId);
+        }
+
+        @Test
+        @DisplayName("providerMessageId는 null을 허용한다 (provider가 ID를 반환하지 않는 경우)")
+        void it_allows_null_provider_message_id() {
+            // given & when
+            final SentResult result = SentResult.of(SENT_AT, null);
+
+            // then
+            assertThat(result.providerMessageId()).isNull();
+        }
+
+        @Test
+        @DisplayName("sentAt이 null이면 NPE를 던진다")
+        void it_throws_when_sent_at_is_null() {
+            assertThatNullPointerException()
+                    .isThrownBy(() -> SentResult.of(null, "msg-001"))
+                    .withMessageContaining("sentAt");
+        }
+    }
+}

--- a/notification-core/src/testFixtures/java/com/liveklass/notification/fixture/DomainEventOutboxFixture.java
+++ b/notification-core/src/testFixtures/java/com/liveklass/notification/fixture/DomainEventOutboxFixture.java
@@ -1,0 +1,78 @@
+package com.liveklass.notification.fixture;
+
+import com.liveklass.common.event.ChannelType;
+import com.liveklass.common.event.Topic;
+import com.liveklass.notification.domain.DedupKey;
+import com.liveklass.notification.domain.DomainEventOutbox;
+import com.liveklass.notification.domain.RetryState;
+import com.liveklass.notification.domain.vo.EventRef;
+import com.liveklass.notification.domain.vo.OutboxId;
+import com.liveklass.notification.domain.vo.ProcessingLock;
+import com.liveklass.notification.domain.vo.SentResult;
+
+import java.time.LocalDateTime;
+
+public final class DomainEventOutboxFixture {
+
+    private static final LocalDateTime DEFAULT_NOW = LocalDateTime.of(2026, 4, 24, 12, 0);
+    private static final EventRef DEFAULT_EMAIL_EVENT =
+            new EventRef(Topic.PAYMENT_CONFIRMED, ChannelType.EMAIL, "pay-001");
+    private static final EventRef DEFAULT_IN_APP_EVENT =
+            new EventRef(Topic.LECTURE_ENROLLMENT_COMPLETED, ChannelType.IN_APP, "enroll-100");
+
+    private DomainEventOutboxFixture() {}
+
+    public static DomainEventOutbox pending() {
+        return DomainEventOutbox.create(
+                DedupKey.of(Topic.PAYMENT_CONFIRMED, 1L, ChannelType.EMAIL, "pay-001"),
+                1L,
+                DEFAULT_EMAIL_EVENT,
+                "{\"subject\":\"결제 완료\",\"body\":\"49,000원\",\"metadata\":{\"recipientEmail\":\"user@example.com\"}}",
+                DEFAULT_NOW,
+                null,
+                3
+        );
+    }
+
+    public static DomainEventOutbox pendingInApp() {
+        return DomainEventOutbox.create(
+                DedupKey.of(Topic.LECTURE_ENROLLMENT_COMPLETED, 1L, ChannelType.IN_APP, "enroll-100"),
+                1L,
+                DEFAULT_IN_APP_EVENT,
+                "{\"title\":\"수강 신청 완료\",\"body\":\"Spring Boot 수강 신청이 완료되었습니다.\",\"metadata\":{}}",
+                DEFAULT_NOW,
+                null,
+                3
+        );
+    }
+
+    public static DomainEventOutbox pendingWithMaxAttempts(final int maxAttempts, final String referenceId) {
+        final EventRef eventRef = new EventRef(Topic.PAYMENT_CONFIRMED, ChannelType.EMAIL, referenceId);
+        return DomainEventOutbox.create(
+                DedupKey.of(Topic.PAYMENT_CONFIRMED, 1L, ChannelType.EMAIL, referenceId),
+                1L,
+                eventRef,
+                "{\"subject\":\"결제 완료\",\"body\":\"본문\",\"metadata\":{\"recipientEmail\":\"user@example.com\"}}",
+                DEFAULT_NOW,
+                null,
+                maxAttempts
+        );
+    }
+
+    public static DomainEventOutbox processing() {
+        return pending().claim(DEFAULT_NOW);
+    }
+
+    public static DomainEventOutbox stuckProcessing() {
+        return pending().claim(DEFAULT_NOW.minusMinutes(10));
+    }
+
+    public static DomainEventOutbox sent() {
+        return processing().complete("msg-abc123", DEFAULT_NOW.plusSeconds(1));
+    }
+
+    public static DomainEventOutbox deadLetter(final String referenceId) {
+        final DomainEventOutbox outbox = pendingWithMaxAttempts(1, referenceId);
+        return outbox.claim(DEFAULT_NOW).fail("fatal error", DEFAULT_NOW.plusMinutes(1));
+    }
+}

--- a/notification-core/src/testFixtures/java/com/liveklass/notification/fixture/NotificationFixture.java
+++ b/notification-core/src/testFixtures/java/com/liveklass/notification/fixture/NotificationFixture.java
@@ -1,0 +1,39 @@
+package com.liveklass.notification.fixture;
+
+import com.liveklass.common.event.Topic;
+import com.liveklass.notification.domain.Notification;
+
+import java.time.LocalDateTime;
+
+public final class NotificationFixture {
+
+    private static final LocalDateTime DEFAULT_NOW = LocalDateTime.of(2026, 4, 24, 12, 0);
+
+    private NotificationFixture() {}
+
+    public static Notification unread() {
+        return Notification.create(
+                10L,
+                1L,
+                Topic.LECTURE_ENROLLMENT_COMPLETED,
+                "{\"title\":\"수강 신청 완료\",\"body\":\"Spring Boot 수강 신청이 완료되었습니다.\",\"metadata\":{}}",
+                DEFAULT_NOW
+        );
+    }
+
+    public static Notification unread(final Long outboxId, final Long recipientId) {
+        return Notification.create(
+                outboxId,
+                recipientId,
+                Topic.LECTURE_ENROLLMENT_COMPLETED,
+                "{\"title\":\"수강 신청 완료\",\"body\":\"본문\",\"metadata\":{}}",
+                DEFAULT_NOW
+        );
+    }
+
+    public static Notification read() {
+        final Notification notification = unread();
+        notification.markRead();
+        return notification;
+    }
+}


### PR DESCRIPTION
## 📌 한눈에 보기

| 구분 | 내용 |
| --- | --- |
| 도메인 모델 | DomainEventOutbox, Notification, RetryState, DedupKey |
| Value Object | OutboxId, EventRef, ProcessingLock, SentResult |
| 예외 | OutboxException(OUTBOX_001~006), NotificationException(NOTIFICATION_001~002) |
| 공통 유틸 | ExceptionAssertions (liveklass-common testFixtures) |
| 테스트 | 도메인 모델·VO 단위 테스트 전체 커버 |

## 🔧 상세 변경

### 1. 공통 (liveklass-common)
- `ExceptionAssertions` 추가 — 예외 타입·메시지를 ExceptionInterface 기준으로 검증하는 테스트 유틸
- `build.gradle` — java-test-fixtures 플러그인 추가

### 2. 예외 enum
- `OutboxException` — outbox 도메인 오류 6종 (상태 전이, DedupKey, RetryState, ProcessingLock, Outbox 불변식, Not Found)
- `NotificationException` — 알림 도메인 오류 2종 (Not Found, Invalid Payload)

### 3. 도메인 모델
- `OutboxStatus` — PENDING/PROCESSING/SENT/DEAD_LETTER 상태 전이 규칙 (validateTransitionTo)
- `OutboxId`, `EventRef`, `SentResult` — outbox 식별자·이벤트 참조·전송 결과 VO
- `ProcessingLock` — PROCESSING ↔ lockedAt 불변식 강제 VO
- `RetryState` — 재시도 횟수·에러·스케줄 관리 모델
- `DedupKey` — 중복 방지 키 포맷(topic:recipientId:channelType:referenceId) 및 512자 제한
- `DomainEventOutbox` — Transactional Outbox 애그리거트 (claim/complete/fail/markDeadLetter/recover/correctToSent/releaseToRetry)
- `Notification` — 알림 엔티티 (create/markRead)

### 4. 테스트 픽스처 & 단위 테스트
- `DomainEventOutboxFixture`, `NotificationFixture` 추가
- VO 및 도메인 모델 전체 단위 테스트 추가 (BDD Nested 구조)

## 🧪 검증
- `./gradlew :notification-core:test`

## ✅ 체크리스트
- [x] 코드 작성 완료
- [x] 단위 테스트 작성
- [x] 로컬 환경 테스트