### PR TITLE
common 이벤트 payload 검증 추가

### DIFF
--- a/liveklass-common/src/main/java/com/liveklass/common/event/PayloadValidator.java
+++ b/liveklass-common/src/main/java/com/liveklass/common/event/PayloadValidator.java
@@ -1,0 +1,52 @@
+package com.liveklass.common.event;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.Objects;
+
+public final class PayloadValidator {
+
+    private PayloadValidator() {}
+
+    public static void validateTopicChannel(final Topic topic, final ChannelType expectedChannelType) {
+        Objects.requireNonNull(topic, "topic must not be null");
+        Objects.requireNonNull(expectedChannelType, "expectedChannelType must not be null");
+        if (topic.getChannelType() != expectedChannelType) {
+            throw new IllegalArgumentException("topic must support " + expectedChannelType + " channel");
+        }
+    }
+
+    public static void validateNotBlank(final String fieldName, final String value) {
+        Objects.requireNonNull(value, fieldName + " must not be null");
+        if (value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+    }
+
+    public static void validateBodyNode(final String fieldName, final JsonNode bodyNode) {
+        Objects.requireNonNull(bodyNode, fieldName + " must not be null");
+        if (bodyNode.isMissingNode() || bodyNode.isNull()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        if (bodyNode.isTextual() && bodyNode.asText().isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+    }
+
+    public static void validate(final ChannelType channelType, final JsonNode payload) {
+        Objects.requireNonNull(channelType, "channelType must not be null");
+        Objects.requireNonNull(payload, "payload must not be null");
+
+        switch (channelType) {
+            case IN_APP -> {
+                validateNotBlank("title", payload.path("title").asText());
+                validateNotBlank("body", payload.path("body").asText());
+            }
+            case EMAIL -> {
+                validateNotBlank("subject", payload.path("subject").asText());
+                validateBodyNode("body", payload.path("body"));
+                validateNotBlank("recipientEmail", payload.path("metadata").path("recipientEmail").asText());
+            }
+        }
+    }
+}

--- a/liveklass-common/src/main/java/com/liveklass/common/event/Topic.java
+++ b/liveklass-common/src/main/java/com/liveklass/common/event/Topic.java
@@ -1,10 +1,18 @@
 package com.liveklass.common.event;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum Topic {
-    LECTURE_ENROLLMENT_COMPLETED,
-    LECTURE_ENROLLMENT_CANCELLED,
-    PAYMENT_CONFIRMED,
-    LECTURE_STARTING_SOON,
-    IN_APP_NOTIFICATION_REQUEST,
-    EMAIL_NOTIFICATION_REQUEST
+
+    LECTURE_ENROLLMENT_COMPLETED (ChannelType.IN_APP),
+    LECTURE_ENROLLMENT_CANCELLED (ChannelType.IN_APP),
+    PAYMENT_CONFIRMED            (ChannelType.EMAIL),
+    LECTURE_STARTING_SOON        (ChannelType.IN_APP),
+    IN_APP_NOTIFICATION_REQUEST  (ChannelType.IN_APP),
+    EMAIL_NOTIFICATION_REQUEST   (ChannelType.EMAIL);
+
+    private final ChannelType channelType;
 }


### PR DESCRIPTION
## 📌 한눈에 보기

| 구분 | 내용 |
| --- | --- |
| 범위 | liveklass-common 이벤트 채널 메타데이터와 payload 검증 추가 |
| 계약 | Topic에 channelType 메타데이터 추가 |
| 검증 | PayloadValidator로 채널별 필수 값 검증 추가 |
| 검증 명령 | ./gradlew :liveklass-common:compileJava --no-daemon |

## 🔧 상세 변경

### 1. 이벤트 채널 계약 명시
- Topic enum에 channelType 필드를 추가해 토픽별 지원 채널을 명시했습니다.
- 토픽과 채널 타입의 조합을 공통 계약으로 사용할 수 있게 정리했습니다.

### 2. payload 공통 검증 추가
- PayloadValidator를 추가해 IN_APP, EMAIL 채널별 필수 필드를 검증하도록 구성했습니다.
- EMAIL은 subject, ody, metadata.recipientEmail을 검증합니다.
- IN_APP은 	itle, ody를 검증합니다.

## 🧪 검증
- ./gradlew :liveklass-common:compileJava --no-daemon

## ✅ 체크리스트
- [x] 공통 이벤트 채널 메타데이터 추가
- [x] 공통 payload 검증 유틸 추가
- [x] liveklass-common 컴파일 확인