### PR TITLE
notification-core 영속성 레이어 구현

### DIFF
--- a/notification-core/build.gradle
+++ b/notification-core/build.gradle
@@ -4,10 +4,11 @@ plugins {
 }
 
 dependencies {
-	implementation project(':liveklass-common')                   // Topic, ChannelType 등 공통 계약 내부 의존
+	implementation project(':liveklass-common')
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	runtimeOnly 'com.mysql:mysql-connector-j'
-	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testFixturesImplementation project(':liveklass-common')
 	testImplementation(testFixtures(project(':liveklass-common')))
 }

--- a/notification-core/src/main/java/com/liveklass/notification/application/repository/InAppNotificationRepository.java
+++ b/notification-core/src/main/java/com/liveklass/notification/application/repository/InAppNotificationRepository.java
@@ -8,9 +8,13 @@ import java.util.Optional;
 
 public interface InAppNotificationRepository {
 
-    InAppNotification save(InAppNotification notification);
+    void save(InAppNotification notification);
+
+    void saveAll(List<InAppNotification> notifications);
 
     Optional<InAppNotification> findById(NotificationId id);
+
+    boolean existsByOutboxId(Long outboxId);
 
     List<InAppNotification> findAllByRecipientId(Long recipientId);
 

--- a/notification-core/src/main/java/com/liveklass/notification/application/repository/OutboxRepository.java
+++ b/notification-core/src/main/java/com/liveklass/notification/application/repository/OutboxRepository.java
@@ -9,13 +9,15 @@ import java.util.Optional;
 
 public interface OutboxRepository {
 
-    DomainEventOutbox save(DomainEventOutbox outbox);
+    void save(DomainEventOutbox outbox);
 
     List<DomainEventOutbox> saveAll(List<DomainEventOutbox> outboxes);
 
+    List<DomainEventOutbox> saveAllProcessingResults(List<DomainEventOutbox> outboxes);
+
     Optional<DomainEventOutbox> findById(OutboxId id);
 
-    List<DomainEventOutbox> findTop50PendingBefore(LocalDateTime scheduledAt);
+    List<DomainEventOutbox> findPendingBefore(LocalDateTime scheduledAt, int limit);
 
     List<DomainEventOutbox> findStuckProcessing(LocalDateTime lockedBefore);
 }

--- a/notification-core/src/main/java/com/liveklass/notification/application/service/InAppNotificationService.java
+++ b/notification-core/src/main/java/com/liveklass/notification/application/service/InAppNotificationService.java
@@ -19,7 +19,7 @@ public class InAppNotificationService {
     private final InAppNotificationRepository notificationRepository;
 
     @Transactional
-    public InAppNotification createInAppNotification(
+    public void createInAppNotification(
             final Long outboxId,
             final Long recipientId,
             final String title,
@@ -27,17 +27,23 @@ public class InAppNotificationService {
             final LocalDateTime publishedAt,
             final LocalDateTime createdAt
     ) {
-        return notificationRepository.save(
+        notificationRepository.save(
                 InAppNotification.create(outboxId, recipientId, title, body, publishedAt, createdAt)
         );
     }
 
     @Transactional
-    public InAppNotification markAsRead(final Long notificationId) {
+    public void createInAppNotificationsBatch(final List<InAppNotification> notifications) {
+        notificationRepository.saveAll(notifications);
+    }
+
+    @Transactional
+    public void markAsRead(final Long notificationId) {
         final InAppNotification notification = notificationRepository.findById(new NotificationId(notificationId))
                 .orElseThrow(() -> ExceptionCreator.create(NotificationException.NOTIFICATION_NOT_FOUND,
                         "notificationId: " + notificationId));
-        return notificationRepository.save(notification.markRead());
+
+        notificationRepository.save(notification.markRead());
     }
 
     @Transactional(readOnly = true)
@@ -57,5 +63,10 @@ public class InAppNotificationService {
     @Transactional(readOnly = true)
     public List<InAppNotification> findAllByRecipientId(final Long recipientId, final boolean isRead) {
         return notificationRepository.findAllByRecipientIdAndIsRead(recipientId, isRead);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean existsByOutboxId(final Long outboxId) {
+        return notificationRepository.existsByOutboxId(outboxId);
     }
 }

--- a/notification-core/src/main/java/com/liveklass/notification/application/service/OutboxService.java
+++ b/notification-core/src/main/java/com/liveklass/notification/application/service/OutboxService.java
@@ -23,7 +23,7 @@ public class OutboxService {
     private final OutboxRepository outboxRepository;
 
     @Transactional
-    public DomainEventOutbox createOutbox(
+    public void createOutbox(
             final String idempotencyKey,
             final Long requesterId,
             final Long recipientId,
@@ -34,7 +34,7 @@ public class OutboxService {
             final LocalDateTime nextAttemptAt,
             final int maxAttempts
     ) {
-        return outboxRepository.save(
+        outboxRepository.save(
                 DomainEventOutbox.create(
                         new IdempotencyKey(idempotencyKey),
                         requesterId,
@@ -48,16 +48,20 @@ public class OutboxService {
     }
 
     @Transactional
-    public List<DomainEventOutbox> claimAll(final List<DomainEventOutbox> outboxes, final LocalDateTime lockedAt) {
-        final List<DomainEventOutbox> claimed = outboxes.stream()
-                .map(o -> o.claim(lockedAt))
+    public List<DomainEventOutbox> claimPendingOutboxes(final LocalDateTime now, final int batchSize) {
+        final List<DomainEventOutbox> pending = outboxRepository.findPendingBefore(now, batchSize);
+        if (pending.isEmpty()) {
+            return List.of();
+        }
+        final List<DomainEventOutbox> claimed = pending.stream()
+                .map(o -> o.claim(now))
                 .toList();
         return outboxRepository.saveAll(claimed);
     }
 
     @Transactional
-    public List<DomainEventOutbox> saveAll(final List<DomainEventOutbox> outboxes) {
-        return outboxRepository.saveAll(outboxes);
+    public List<DomainEventOutbox> saveAllProcessingResults(final List<DomainEventOutbox> outboxes) {
+        return outboxRepository.saveAllProcessingResults(outboxes);
     }
 
     @Transactional(readOnly = true)
@@ -70,11 +74,6 @@ public class OutboxService {
         }
         outbox.validateRequester(requesterId);
         return outbox;
-    }
-
-    @Transactional(readOnly = true)
-    public List<DomainEventOutbox> findPendingOutboxes(final LocalDateTime scheduledAt) {
-        return outboxRepository.findTop50PendingBefore(scheduledAt);
     }
 
     @Transactional(readOnly = true)

--- a/notification-core/src/main/java/com/liveklass/notification/domain/DomainEventOutbox.java
+++ b/notification-core/src/main/java/com/liveklass/notification/domain/DomainEventOutbox.java
@@ -60,7 +60,6 @@ public record DomainEventOutbox(
         lock.status().validateTransitionTo(OutboxStatus.PROCESSING);
         return toBuilder()
                 .lock(ProcessingLock.processing(Objects.requireNonNull(lockedAt)))
-                .retryState(retryState.increment(retryState.nextAttemptAt()))
                 .build();
     }
 
@@ -69,18 +68,33 @@ public record DomainEventOutbox(
         lock.status().validateTransitionTo(OutboxStatus.SENT);
         return toBuilder()
                 .lock(ProcessingLock.sent())
+                .retryState(retryState.recordSuccess())
                 .build();
     }
 
     /** PROCESSING → PENDING (retry) or DEAD_LETTER */
     public DomainEventOutbox fail(final String error, final LocalDateTime nextAttemptAt) {
-        if (!retryState.isRetryable()) {
-            return markDeadLetter(error);
+        final RetryState failedState = retryState.recordFailure(error, nextAttemptAt);
+        if (!failedState.isRetryable()) {
+            lock.status().validateTransitionTo(OutboxStatus.DEAD_LETTER);
+            return toBuilder()
+                    .lock(ProcessingLock.deadLetter())
+                    .retryState(failedState)
+                    .build();
         }
         lock.status().validateTransitionTo(OutboxStatus.PENDING);
         return toBuilder()
                 .lock(ProcessingLock.pending())
-                .retryState(retryState.withFailure(error, Objects.requireNonNull(nextAttemptAt)))
+                .retryState(failedState)
+                .build();
+    }
+
+    /** PROCESSING → DEAD_LETTER */
+    public DomainEventOutbox permanentFail(final String error) {
+        lock.status().validateTransitionTo(OutboxStatus.DEAD_LETTER);
+        return toBuilder()
+                .lock(ProcessingLock.deadLetter())
+                .retryState(retryState.recordFailure(error, retryState.nextAttemptAt()))
                 .build();
     }
 
@@ -107,6 +121,7 @@ public record DomainEventOutbox(
         lock.status().validateTransitionTo(OutboxStatus.SENT);
         return toBuilder()
                 .lock(ProcessingLock.sent())
+                .retryState(retryState.recordSuccess())
                 .build();
     }
 
@@ -125,8 +140,7 @@ public record DomainEventOutbox(
 
     public void validateRequester(final Long requesterId) {
         if (!this.requesterId.equals(requesterId)) {
-            throw ExceptionCreator.create(OutboxException.OUTBOX_ACCESS_DENIED,
-                    "outboxId: " + id.id());
+            throw ExceptionCreator.create(OutboxException.OUTBOX_ACCESS_DENIED, "outboxId: " + id.id());
         }
     }
 }

--- a/notification-core/src/main/java/com/liveklass/notification/domain/event/InAppNotificationEvent.java
+++ b/notification-core/src/main/java/com/liveklass/notification/domain/event/InAppNotificationEvent.java
@@ -33,6 +33,8 @@ public record InAppNotificationEvent(
 
     @Override
     public JsonNode payload() {
-        return InAppPayload.builder(title, body).build();
+        return InAppPayload.builder(title, body)
+                .metadata("publishedAt", publishedAt.toString())
+                .build();
     }
 }

--- a/notification-core/src/main/java/com/liveklass/notification/domain/vo/ProcessingLock.java
+++ b/notification-core/src/main/java/com/liveklass/notification/domain/vo/ProcessingLock.java
@@ -26,4 +26,13 @@ public record ProcessingLock(
     public static ProcessingLock processing(final LocalDateTime lockedAt) { return new ProcessingLock(OutboxStatus.PROCESSING, lockedAt); }
     public static ProcessingLock sent()                                { return new ProcessingLock(OutboxStatus.SENT, null); }
     public static ProcessingLock deadLetter()                          { return new ProcessingLock(OutboxStatus.DEAD_LETTER, null); }
+
+    public static ProcessingLock of(final OutboxStatus status, final LocalDateTime lockedAt) {
+        return switch (status) {
+            case PROCESSING  -> processing(lockedAt);
+            case SENT        -> sent();
+            case DEAD_LETTER -> deadLetter();
+            case PENDING     -> pending();
+        };
+    }
 }

--- a/notification-core/src/main/java/com/liveklass/notification/domain/vo/RetryState.java
+++ b/notification-core/src/main/java/com/liveklass/notification/domain/vo/RetryState.java
@@ -37,6 +37,15 @@ public record RetryState(
                 Objects.requireNonNull(nextAttemptAt), lastError);
     }
 
+    public RetryState recordSuccess() {
+        return new RetryState(attemptCount + 1, maxAttempts, nextAttemptAt, null);
+    }
+
+    public RetryState recordFailure(final String error, final LocalDateTime nextAttemptAt) {
+        return new RetryState(attemptCount + 1, maxAttempts,
+                Objects.requireNonNull(nextAttemptAt), error);
+    }
+
     public RetryState withFailure(final String error, final LocalDateTime nextAttemptAt) {
         return new RetryState(attemptCount, maxAttempts,
                 Objects.requireNonNull(nextAttemptAt), error);

--- a/notification-core/src/main/java/com/liveklass/notification/infrastructure/mapper/InAppNotificationEntityMapper.java
+++ b/notification-core/src/main/java/com/liveklass/notification/infrastructure/mapper/InAppNotificationEntityMapper.java
@@ -1,0 +1,23 @@
+package com.liveklass.notification.infrastructure.mapper;
+
+import com.liveklass.notification.domain.InAppNotification;
+import com.liveklass.notification.domain.id.NotificationId;
+import com.liveklass.notification.infrastructure.persistence.entity.InAppNotificationJpaEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InAppNotificationEntityMapper {
+
+    public InAppNotification toDomain(final InAppNotificationJpaEntity entity) {
+        return new InAppNotification(
+                new NotificationId(entity.getId()),
+                entity.getOutboxId(),
+                entity.getRecipientId(),
+                entity.getTitle(),
+                entity.getBody(),
+                entity.isRead(),
+                entity.getPublishedAt(),
+                entity.getCreatedAt()
+        );
+    }
+}

--- a/notification-core/src/main/java/com/liveklass/notification/infrastructure/mapper/OutboxEntityMapper.java
+++ b/notification-core/src/main/java/com/liveklass/notification/infrastructure/mapper/OutboxEntityMapper.java
@@ -1,0 +1,31 @@
+package com.liveklass.notification.infrastructure.mapper;
+
+import com.liveklass.notification.domain.DomainEventOutbox;
+import com.liveklass.notification.domain.id.OutboxId;
+import com.liveklass.notification.domain.vo.EventRef;
+import com.liveklass.notification.domain.vo.ProcessingLock;
+import com.liveklass.notification.domain.vo.RetryState;
+import com.liveklass.notification.infrastructure.persistence.entity.OutboxJpaEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OutboxEntityMapper {
+
+    public DomainEventOutbox toDomain(final OutboxJpaEntity entity) {
+        return DomainEventOutbox.builder()
+                .id(new OutboxId(entity.getId()))
+                .idempotencyKey(entity.getIdempotencyKey())
+                .requesterId(entity.getRequesterId())
+                .recipientId(entity.getRecipientId())
+                .eventRef(new EventRef(entity.getTopic(), entity.getChannelType(), entity.getReferenceId()))
+                .payload(entity.getPayload())
+                .lock(ProcessingLock.of(entity.getStatus(), entity.getLockedAt()))
+                .retryState(new RetryState(
+                        entity.getAttemptCount(),
+                        entity.getMaxAttempts(),
+                        entity.getNextAttemptAt(),
+                        entity.getLastError()
+                ))
+                .build();
+    }
+}

--- a/notification-core/src/main/java/com/liveklass/notification/infrastructure/persistence/entity/InAppNotificationJpaEntity.java
+++ b/notification-core/src/main/java/com/liveklass/notification/infrastructure/persistence/entity/InAppNotificationJpaEntity.java
@@ -1,0 +1,49 @@
+package com.liveklass.notification.infrastructure.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "in_app_notification")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class InAppNotificationJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "outbox_id", nullable = false)
+    private Long outboxId;
+
+    @Column(name = "recipient_id", nullable = false)
+    private Long recipientId;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "body", nullable = false, columnDefinition = "TEXT")
+    private String body;
+
+    @Column(name = "is_read", nullable = false)
+    private boolean isRead;
+
+    @Column(name = "published_at", nullable = false)
+    private LocalDateTime publishedAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/notification-core/src/main/java/com/liveklass/notification/infrastructure/persistence/entity/OutboxJpaEntity.java
+++ b/notification-core/src/main/java/com/liveklass/notification/infrastructure/persistence/entity/OutboxJpaEntity.java
@@ -1,0 +1,76 @@
+package com.liveklass.notification.infrastructure.persistence.entity;
+
+import com.liveklass.common.event.ChannelType;
+import com.liveklass.common.event.Topic;
+import com.liveklass.notification.domain.enums.OutboxStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "domain_event_outbox")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class OutboxJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "idempotency_key", nullable = false, unique = true)
+    private String idempotencyKey;
+
+    @Column(name = "requester_id", nullable = false)
+    private Long requesterId;
+
+    @Column(name = "recipient_id", nullable = false)
+    private Long recipientId;
+
+    @Column(name = "topic", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Topic topic;
+
+    @Column(name = "channel_type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ChannelType channelType;
+
+    @Column(name = "reference_id")
+    private String referenceId;
+
+    @Column(name = "payload", nullable = false, columnDefinition = "TEXT")
+    private String payload;
+
+    @Column(name = "status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private OutboxStatus status;
+
+    @Column(name = "locked_at")
+    private LocalDateTime lockedAt;
+
+    @Column(name = "attempt_count", nullable = false)
+    private int attemptCount;
+
+    @Column(name = "max_attempts", nullable = false)
+    private int maxAttempts;
+
+    @Column(name = "next_attempt_at", nullable = false)
+    private LocalDateTime nextAttemptAt;
+
+    @Column(name = "last_error")
+    private String lastError;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/notification-core/src/main/java/com/liveklass/notification/infrastructure/persistence/jdbc/JdbcInAppNotificationRepository.java
+++ b/notification-core/src/main/java/com/liveklass/notification/infrastructure/persistence/jdbc/JdbcInAppNotificationRepository.java
@@ -1,0 +1,12 @@
+package com.liveklass.notification.infrastructure.persistence.jdbc;
+
+import com.liveklass.notification.domain.InAppNotification;
+
+import java.util.List;
+
+public interface JdbcInAppNotificationRepository {
+
+    void upsert(InAppNotification notification);
+
+    void batchInsert(List<InAppNotification> notifications);
+}

--- a/notification-core/src/main/java/com/liveklass/notification/infrastructure/persistence/jdbc/JdbcInAppNotificationRepositoryImpl.java
+++ b/notification-core/src/main/java/com/liveklass/notification/infrastructure/persistence/jdbc/JdbcInAppNotificationRepositoryImpl.java
@@ -1,0 +1,49 @@
+package com.liveklass.notification.infrastructure.persistence.jdbc;
+
+import com.liveklass.notification.domain.InAppNotification;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class JdbcInAppNotificationRepositoryImpl implements JdbcInAppNotificationRepository {
+
+    private static final String UPSERT_SQL =
+            "INSERT INTO in_app_notification " +
+            "(outbox_id, recipient_id, title, body, is_read, published_at, created_at, updated_at) " +
+            "VALUES (?, ?, ?, ?, ?, ?, now(), now()) " +
+            "ON DUPLICATE KEY UPDATE outbox_id = outbox_id";
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public void upsert(final InAppNotification notification) {
+        jdbcTemplate.update(con -> {
+            final PreparedStatement ps = con.prepareStatement(UPSERT_SQL);
+            ps.setLong(1, notification.outboxId());
+            ps.setLong(2, notification.recipientId());
+            ps.setString(3, notification.title());
+            ps.setString(4, notification.body());
+            ps.setBoolean(5, notification.isRead());
+            ps.setTimestamp(6, Timestamp.valueOf(notification.publishedAt()));
+            return ps;
+        });
+    }
+
+    @Override
+    public void batchInsert(final List<InAppNotification> notifications) {
+        jdbcTemplate.batchUpdate(UPSERT_SQL, notifications, notifications.size(), (ps, n) -> {
+            ps.setLong(1, n.outboxId());
+            ps.setLong(2, n.recipientId());
+            ps.setString(3, n.title());
+            ps.setString(4, n.body());
+            ps.setBoolean(5, n.isRead());
+            ps.setTimestamp(6, Timestamp.valueOf(n.publishedAt()));
+        });
+    }
+}

--- a/notification-core/src/main/java/com/liveklass/notification/infrastructure/persistence/jdbc/JdbcOutboxRepository.java
+++ b/notification-core/src/main/java/com/liveklass/notification/infrastructure/persistence/jdbc/JdbcOutboxRepository.java
@@ -1,0 +1,17 @@
+package com.liveklass.notification.infrastructure.persistence.jdbc;
+
+import com.liveklass.notification.domain.DomainEventOutbox;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface JdbcOutboxRepository {
+
+    void upsert(DomainEventOutbox outbox);
+
+    void batchUpdate(List<DomainEventOutbox> outboxes);
+
+    void batchUpdateProcessingResults(List<DomainEventOutbox> outboxes);
+
+    List<DomainEventOutbox> findPendingBefore(LocalDateTime scheduledAt, int limit);
+}

--- a/notification-core/src/main/java/com/liveklass/notification/infrastructure/persistence/jdbc/JdbcOutboxRepositoryImpl.java
+++ b/notification-core/src/main/java/com/liveklass/notification/infrastructure/persistence/jdbc/JdbcOutboxRepositoryImpl.java
@@ -1,0 +1,145 @@
+package com.liveklass.notification.infrastructure.persistence.jdbc;
+
+import com.liveklass.common.event.ChannelType;
+import com.liveklass.common.event.Topic;
+import com.liveklass.notification.domain.DomainEventOutbox;
+import com.liveklass.notification.domain.enums.OutboxStatus;
+import com.liveklass.notification.domain.id.OutboxId;
+import com.liveklass.notification.domain.vo.EventRef;
+import com.liveklass.notification.domain.vo.ProcessingLock;
+import com.liveklass.notification.domain.vo.RetryState;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class JdbcOutboxRepositoryImpl implements JdbcOutboxRepository {
+
+    private static final String UPSERT_SQL =
+            "INSERT INTO domain_event_outbox " +
+            "(idempotency_key, requester_id, recipient_id, topic, channel_type, reference_id, payload, " +
+            " status, locked_at, attempt_count, max_attempts, next_attempt_at, last_error, created_at, updated_at) " +
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, now(), now()) " +
+            "ON DUPLICATE KEY UPDATE idempotency_key = idempotency_key";
+
+    private static final String BATCH_UPDATE_SQL =
+            "UPDATE domain_event_outbox " +
+            "SET status=?, locked_at=?, attempt_count=?, max_attempts=?, next_attempt_at=?, last_error=?, updated_at=now() " +
+            "WHERE id=?";
+
+    private static final String BATCH_UPDATE_PROCESSING_RESULTS_SQL =
+            "UPDATE domain_event_outbox " +
+            "SET status=?, locked_at=?, attempt_count=?, max_attempts=?, next_attempt_at=?, last_error=?, updated_at=now() " +
+            "WHERE id=? AND status='PROCESSING'";
+
+    private static final String SELECT_PENDING_SQL =
+            "SELECT * FROM domain_event_outbox " +
+            "WHERE status = 'PENDING' AND next_attempt_at <= ? " +
+            "ORDER BY next_attempt_at, id LIMIT ? " +
+            "FOR UPDATE SKIP LOCKED";
+
+    static final RowMapper<DomainEventOutbox> ROW_MAPPER = (rs, rowNum) -> {
+        final OutboxStatus status = OutboxStatus.valueOf(rs.getString("status"));
+        final LocalDateTime lockedAt = rs.getTimestamp("locked_at") != null
+                ? rs.getTimestamp("locked_at").toLocalDateTime() : null;
+        return DomainEventOutbox.builder()
+                .id(new OutboxId(rs.getLong("id")))
+                .idempotencyKey(rs.getString("idempotency_key"))
+                .requesterId(rs.getLong("requester_id"))
+                .recipientId(rs.getLong("recipient_id"))
+                .eventRef(new EventRef(
+                        Topic.valueOf(rs.getString("topic")),
+                        ChannelType.valueOf(rs.getString("channel_type")),
+                        rs.getString("reference_id")
+                ))
+                .payload(rs.getString("payload"))
+                .lock(ProcessingLock.of(status, lockedAt))
+                .retryState(new RetryState(
+                        rs.getInt("attempt_count"),
+                        rs.getInt("max_attempts"),
+                        rs.getTimestamp("next_attempt_at").toLocalDateTime(),
+                        rs.getString("last_error")
+                ))
+                .build();
+    };
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public void upsert(final DomainEventOutbox outbox) {
+        jdbcTemplate.update(con -> {
+            final PreparedStatement ps = con.prepareStatement(UPSERT_SQL);
+            ps.setString(1, outbox.idempotencyKey());
+            ps.setLong(2, outbox.requesterId());
+            ps.setLong(3, outbox.recipientId());
+            ps.setString(4, outbox.eventRef().topic().name());
+            ps.setString(5, outbox.eventRef().channelType().name());
+            ps.setString(6, outbox.eventRef().referenceId());
+            ps.setString(7, outbox.payload());
+            ps.setString(8, outbox.status().name());
+            setNullableTimestamp(ps, 9, outbox.lock().lockedAt());
+            ps.setInt(10, outbox.retryState().attemptCount());
+            ps.setInt(11, outbox.retryState().maxAttempts());
+            ps.setTimestamp(12, Timestamp.valueOf(outbox.retryState().nextAttemptAt()));
+            setNullableString(ps, 13, outbox.retryState().lastError());
+            return ps;
+        });
+    }
+
+    @Override
+    public void batchUpdate(final List<DomainEventOutbox> outboxes) {
+        jdbcTemplate.batchUpdate(BATCH_UPDATE_SQL, outboxes, outboxes.size(), (ps, outbox) -> {
+            ps.setString(1, outbox.status().name());
+            setNullableTimestamp(ps, 2, outbox.lock().lockedAt());
+            ps.setInt(3, outbox.retryState().attemptCount());
+            ps.setInt(4, outbox.retryState().maxAttempts());
+            ps.setTimestamp(5, Timestamp.valueOf(outbox.retryState().nextAttemptAt()));
+            setNullableString(ps, 6, outbox.retryState().lastError());
+            ps.setLong(7, outbox.id().id());
+        });
+    }
+
+    @Override
+    public void batchUpdateProcessingResults(final List<DomainEventOutbox> outboxes) {
+        jdbcTemplate.batchUpdate(BATCH_UPDATE_PROCESSING_RESULTS_SQL, outboxes, outboxes.size(), (ps, outbox) -> {
+            ps.setString(1, outbox.status().name());
+            setNullableTimestamp(ps, 2, outbox.lock().lockedAt());
+            ps.setInt(3, outbox.retryState().attemptCount());
+            ps.setInt(4, outbox.retryState().maxAttempts());
+            ps.setTimestamp(5, Timestamp.valueOf(outbox.retryState().nextAttemptAt()));
+            setNullableString(ps, 6, outbox.retryState().lastError());
+            ps.setLong(7, outbox.id().id());
+        });
+    }
+
+    @Override
+    public List<DomainEventOutbox> findPendingBefore(final LocalDateTime scheduledAt, final int limit) {
+        return jdbcTemplate.query(SELECT_PENDING_SQL, ROW_MAPPER, Timestamp.valueOf(scheduledAt), limit);
+    }
+
+    private static void setNullableTimestamp(final PreparedStatement ps, final int idx, final LocalDateTime value)
+            throws java.sql.SQLException {
+        if (value != null) {
+            ps.setTimestamp(idx, Timestamp.valueOf(value));
+        } else {
+            ps.setNull(idx, Types.TIMESTAMP);
+        }
+    }
+
+    private static void setNullableString(final PreparedStatement ps, final int idx, final String value)
+            throws java.sql.SQLException {
+        if (value != null) {
+            ps.setString(idx, value);
+        } else {
+            ps.setNull(idx, Types.VARCHAR);
+        }
+    }
+}

--- a/notification-core/src/main/java/com/liveklass/notification/infrastructure/persistence/jpa/JpaInAppNotificationRepository.java
+++ b/notification-core/src/main/java/com/liveklass/notification/infrastructure/persistence/jpa/JpaInAppNotificationRepository.java
@@ -1,0 +1,15 @@
+package com.liveklass.notification.infrastructure.persistence.jpa;
+
+import com.liveklass.notification.infrastructure.persistence.entity.InAppNotificationJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface JpaInAppNotificationRepository extends JpaRepository<InAppNotificationJpaEntity, Long> {
+
+    boolean existsByOutboxId(Long outboxId);
+
+    List<InAppNotificationJpaEntity> findAllByRecipientIdOrderByCreatedAtDesc(Long recipientId);
+
+    List<InAppNotificationJpaEntity> findAllByRecipientIdAndIsReadOrderByCreatedAtDesc(Long recipientId, boolean isRead);
+}

--- a/notification-core/src/main/java/com/liveklass/notification/infrastructure/persistence/jpa/JpaOutboxRepository.java
+++ b/notification-core/src/main/java/com/liveklass/notification/infrastructure/persistence/jpa/JpaOutboxRepository.java
@@ -1,0 +1,13 @@
+package com.liveklass.notification.infrastructure.persistence.jpa;
+
+import com.liveklass.notification.domain.enums.OutboxStatus;
+import com.liveklass.notification.infrastructure.persistence.entity.OutboxJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface JpaOutboxRepository extends JpaRepository<OutboxJpaEntity, Long> {
+
+    List<OutboxJpaEntity> findByStatusAndLockedAtBefore(OutboxStatus status, LocalDateTime lockedAt);
+}

--- a/notification-core/src/main/java/com/liveklass/notification/infrastructure/repository/InAppNotificationRepositoryImpl.java
+++ b/notification-core/src/main/java/com/liveklass/notification/infrastructure/repository/InAppNotificationRepositoryImpl.java
@@ -1,0 +1,59 @@
+package com.liveklass.notification.infrastructure.repository;
+
+import com.liveklass.notification.application.repository.InAppNotificationRepository;
+import com.liveklass.notification.domain.InAppNotification;
+import com.liveklass.notification.domain.id.NotificationId;
+import com.liveklass.notification.infrastructure.mapper.InAppNotificationEntityMapper;
+import com.liveklass.notification.infrastructure.persistence.jdbc.JdbcInAppNotificationRepository;
+import com.liveklass.notification.infrastructure.persistence.jpa.JpaInAppNotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class InAppNotificationRepositoryImpl implements InAppNotificationRepository {
+
+    private final JpaInAppNotificationRepository jpaInAppNotificationRepository;
+    private final JdbcInAppNotificationRepository jdbcInAppNotificationRepository;
+    private final InAppNotificationEntityMapper inAppNotificationEntityMapper;
+
+    @Override
+    public void saveAll(final List<InAppNotification> notifications) {
+        jdbcInAppNotificationRepository.batchInsert(notifications);
+    }
+
+    @Override
+    public void save(final InAppNotification notification) {
+        jdbcInAppNotificationRepository.upsert(notification);
+    }
+
+    @Override
+    public Optional<InAppNotification> findById(final NotificationId id) {
+        return jpaInAppNotificationRepository.findById(id.id())
+                .map(inAppNotificationEntityMapper::toDomain);
+    }
+
+    @Override
+    public boolean existsByOutboxId(final Long outboxId) {
+        return jpaInAppNotificationRepository.existsByOutboxId(outboxId);
+    }
+
+    @Override
+    public List<InAppNotification> findAllByRecipientId(final Long recipientId) {
+        return jpaInAppNotificationRepository.findAllByRecipientIdOrderByCreatedAtDesc(recipientId)
+                .stream()
+                .map(inAppNotificationEntityMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<InAppNotification> findAllByRecipientIdAndIsRead(final Long recipientId, final boolean isRead) {
+        return jpaInAppNotificationRepository.findAllByRecipientIdAndIsReadOrderByCreatedAtDesc(recipientId, isRead)
+                .stream()
+                .map(inAppNotificationEntityMapper::toDomain)
+                .toList();
+    }
+}

--- a/notification-core/src/main/java/com/liveklass/notification/infrastructure/repository/OutboxRepositoryImpl.java
+++ b/notification-core/src/main/java/com/liveklass/notification/infrastructure/repository/OutboxRepositoryImpl.java
@@ -1,0 +1,60 @@
+package com.liveklass.notification.infrastructure.repository;
+
+import com.liveklass.notification.application.repository.OutboxRepository;
+import com.liveklass.notification.domain.DomainEventOutbox;
+import com.liveklass.notification.domain.enums.OutboxStatus;
+import com.liveklass.notification.domain.id.OutboxId;
+import com.liveklass.notification.infrastructure.mapper.OutboxEntityMapper;
+import com.liveklass.notification.infrastructure.persistence.jdbc.JdbcOutboxRepository;
+import com.liveklass.notification.infrastructure.persistence.jpa.JpaOutboxRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class OutboxRepositoryImpl implements OutboxRepository {
+
+    private final JpaOutboxRepository jpaOutboxRepository;
+    private final JdbcOutboxRepository jdbcOutboxRepository;
+    private final OutboxEntityMapper outboxEntityMapper;
+
+    @Override
+    public void save(final DomainEventOutbox outbox) {
+        jdbcOutboxRepository.upsert(outbox);
+    }
+
+    @Override
+    public List<DomainEventOutbox> saveAll(final List<DomainEventOutbox> outboxes) {
+        jdbcOutboxRepository.batchUpdate(outboxes);
+        return outboxes;
+    }
+
+    @Override
+    public List<DomainEventOutbox> saveAllProcessingResults(final List<DomainEventOutbox> outboxes) {
+        jdbcOutboxRepository.batchUpdateProcessingResults(outboxes);
+        return outboxes;
+    }
+
+    @Override
+    public Optional<DomainEventOutbox> findById(final OutboxId id) {
+        return jpaOutboxRepository.findById(id.id())
+                .map(outboxEntityMapper::toDomain);
+    }
+
+    @Override
+    public List<DomainEventOutbox> findPendingBefore(final LocalDateTime scheduledAt, final int limit) {
+        return jdbcOutboxRepository.findPendingBefore(scheduledAt, limit);
+    }
+
+    @Override
+    public List<DomainEventOutbox> findStuckProcessing(final LocalDateTime lockedBefore) {
+        return jpaOutboxRepository.findByStatusAndLockedAtBefore(OutboxStatus.PROCESSING, lockedBefore)
+                .stream()
+                .map(outboxEntityMapper::toDomain)
+                .toList();
+    }
+}

--- a/notification-core/src/main/resources/schema.sql
+++ b/notification-core/src/main/resources/schema.sql
@@ -1,0 +1,37 @@
+CREATE TABLE IF NOT EXISTS domain_event_outbox (
+    id              BIGINT          NOT NULL AUTO_INCREMENT,
+    idempotency_key VARCHAR(255)    NOT NULL,
+    requester_id    BIGINT          NOT NULL,
+    recipient_id    BIGINT          NOT NULL,
+    topic           VARCHAR(100)    NOT NULL,
+    channel_type    VARCHAR(50)     NOT NULL,
+    reference_id    VARCHAR(100)    NOT NULL,
+    payload         TEXT            NOT NULL,
+    status          VARCHAR(50)     NOT NULL,
+    locked_at       DATETIME(6),
+    attempt_count   INT             NOT NULL DEFAULT 0,
+    max_attempts    INT             NOT NULL DEFAULT 3,
+    next_attempt_at DATETIME(6)     NOT NULL,
+    last_error      TEXT,
+    created_at      DATETIME(6)     NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at      DATETIME(6)     NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_idempotency_key (idempotency_key),
+    KEY idx_polling (status, next_attempt_at, id),
+    KEY idx_recipient (recipient_id, created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS in_app_notification (
+    id           BIGINT       NOT NULL AUTO_INCREMENT,
+    outbox_id    BIGINT       NOT NULL,
+    recipient_id BIGINT       NOT NULL,
+    title        VARCHAR(500) NOT NULL,
+    body         TEXT         NOT NULL,
+    is_read      BOOLEAN      NOT NULL DEFAULT FALSE,
+    published_at DATETIME(6)  NOT NULL,
+    created_at   DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at   DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_outbox_id (outbox_id),
+    KEY idx_recipient_read (recipient_id, is_read, created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/notification-core/src/test/java/com/liveklass/notification/application/service/InAppNotificationServiceTest.java
+++ b/notification-core/src/test/java/com/liveklass/notification/application/service/InAppNotificationServiceTest.java
@@ -20,8 +20,9 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @Tag("UNIT_TEST")
 @ExtendWith(MockitoExtension.class)
@@ -42,20 +43,43 @@ class InAppNotificationServiceTest {
 
         @Test
         @DisplayName("InAppNotification을 생성하고 저장한다")
-        void it_saves_and_returns_notification() {
-            // given
-            final InAppNotification unread = InAppNotificationFixture.unread(10L, 1L);
-            given(notificationRepository.save(any(InAppNotification.class))).willReturn(unread);
-
+        void it_saves_notification() {
             // when
-            final InAppNotification result = notificationService.createInAppNotification(
+            notificationService.createInAppNotification(
                     10L, 1L, "수강 신청 완료", "Spring Boot 수강 신청이 완료되었습니다.", NOW, NOW
             );
 
             // then
-            assertThat(result.isRead()).isFalse();
-            assertThat(result.recipientId()).isEqualTo(1L);
-            assertThat(result.outboxId()).isEqualTo(10L);
+            verify(notificationRepository).save(argThat(notification ->
+                    !notification.isRead()
+                            && notification.recipientId().equals(1L)
+                            && notification.outboxId().equals(10L)
+                            && notification.title().equals("수강 신청 완료")
+                            && notification.body().equals("Spring Boot 수강 신청이 완료되었습니다.")
+                            && notification.publishedAt().equals(NOW)
+                            && notification.createdAt().equals(NOW)
+            ));
+        }
+    }
+
+    @Nested
+    @DisplayName("createInAppNotificationsBatch()는")
+    class Describe_createInAppNotificationsBatch {
+
+        @Test
+        @DisplayName("알림 목록을 일괄 저장한다")
+        void it_saves_notifications_in_batch() {
+            // given
+            final List<InAppNotification> notifications = List.of(
+                    InAppNotificationFixture.unread(10L, 1L),
+                    InAppNotificationFixture.unread(11L, 1L)
+            );
+
+            // when
+            notificationService.createInAppNotificationsBatch(notifications);
+
+            // then
+            verify(notificationRepository).saveAll(notifications);
         }
     }
 
@@ -70,13 +94,12 @@ class InAppNotificationServiceTest {
             final Long notificationId = 1L;
             final InAppNotification unread = InAppNotificationFixture.unread();
             given(notificationRepository.findById(new NotificationId(notificationId))).willReturn(Optional.of(unread));
-            given(notificationRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
 
             // when
-            final InAppNotification result = notificationService.markAsRead(notificationId);
+            notificationService.markAsRead(notificationId);
 
             // then
-            assertThat(result.isRead()).isTrue();
+            verify(notificationRepository).save(argThat(InAppNotification::isRead));
         }
 
         @Test
@@ -183,6 +206,24 @@ class InAppNotificationServiceTest {
             // then
             assertThat(result).hasSize(1);
             result.forEach(n -> assertThat(n.isRead()).isFalse());
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByOutboxId()는")
+    class Describe_existsByOutboxId {
+
+        @Test
+        @DisplayName("outboxId에 해당하는 인앱 알림 존재 여부를 반환한다")
+        void it_returns_whether_notification_exists_for_outbox() {
+            // given
+            given(notificationRepository.existsByOutboxId(10L)).willReturn(true);
+
+            // when
+            final boolean result = notificationService.existsByOutboxId(10L);
+
+            // then
+            assertThat(result).isTrue();
         }
     }
 }

--- a/notification-core/src/test/java/com/liveklass/notification/application/service/NotificationServiceTest.java
+++ b/notification-core/src/test/java/com/liveklass/notification/application/service/NotificationServiceTest.java
@@ -1,6 +1,5 @@
 package com.liveklass.notification.application.service;
 
-import com.liveklass.common.event.DomainEvent;
 import com.liveklass.common.event.DomainEventPublisher;
 import com.liveklass.common.event.Topic;
 import com.liveklass.notification.domain.event.EmailNotificationEvent;
@@ -50,9 +49,10 @@ class NotificationServiceTest {
             notificationService.requestInAppNotification(recipientId, referenceId, title, body, NOW);
 
             // then
-            final ArgumentCaptor<DomainEvent> captor = ArgumentCaptor.forClass(DomainEvent.class);
+            final ArgumentCaptor<com.liveklass.common.event.DomainEvent> captor =
+                    ArgumentCaptor.forClass(com.liveklass.common.event.DomainEvent.class);
             verify(eventPublisher).publish(captor.capture());
-            final DomainEvent published = captor.getValue();
+            final com.liveklass.common.event.DomainEvent published = captor.getValue();
             assertThat(published).isInstanceOf(InAppNotificationEvent.class);
             final InAppNotificationEvent event = (InAppNotificationEvent) published;
             assertThat(event.topic()).isEqualTo(Topic.IN_APP_NOTIFICATION_REQUEST);
@@ -82,9 +82,10 @@ class NotificationServiceTest {
             notificationService.requestEmailNotification(recipientId, referenceId, subject, body, recipientEmail, NOW);
 
             // then
-            final ArgumentCaptor<DomainEvent> captor = ArgumentCaptor.forClass(DomainEvent.class);
+            final ArgumentCaptor<com.liveklass.common.event.DomainEvent> captor =
+                    ArgumentCaptor.forClass(com.liveklass.common.event.DomainEvent.class);
             verify(eventPublisher).publish(captor.capture());
-            final DomainEvent published = captor.getValue();
+            final com.liveklass.common.event.DomainEvent published = captor.getValue();
             assertThat(published).isInstanceOf(EmailNotificationEvent.class);
             final EmailNotificationEvent event = (EmailNotificationEvent) published;
             assertThat(event.topic()).isEqualTo(Topic.EMAIL_NOTIFICATION_REQUEST);

--- a/notification-core/src/test/java/com/liveklass/notification/application/service/OutboxServiceTest.java
+++ b/notification-core/src/test/java/com/liveklass/notification/application/service/OutboxServiceTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -44,14 +45,13 @@ class OutboxServiceTest {
     class Describe_createOutbox {
 
         @Test
-        @DisplayName("outbox를 저장하고 PENDING 상태로 반환한다")
-        void it_saves_and_returns_pending_outbox() {
+        @DisplayName("outbox를 생성해 PENDING 상태로 저장한다")
+        void it_saves_pending_outbox() {
             // given
             final DomainEventOutbox pending = DomainEventOutboxFixture.pending();
-            given(outboxRepository.save(any(DomainEventOutbox.class))).willReturn(pending);
 
             // when
-            final DomainEventOutbox result = outboxService.createOutbox(
+            outboxService.createOutbox(
                     DomainEventOutboxFixture.defaultIdempotencyKey().value(),
                     pending.requesterId(),
                     pending.recipientId(),
@@ -64,57 +64,69 @@ class OutboxServiceTest {
             );
 
             // then
-            assertThat(result.status()).isEqualTo(OutboxStatus.PENDING);
-            verify(outboxRepository).save(any(DomainEventOutbox.class));
+            verify(outboxRepository).save(argThat(outbox ->
+                    outbox.status() == OutboxStatus.PENDING
+                            && outbox.idempotencyKey().equals(DomainEventOutboxFixture.defaultIdempotencyKey().value())
+                            && outbox.requesterId().equals(pending.requesterId())
+                            && outbox.recipientId().equals(pending.recipientId())
+                            && outbox.eventRef().equals(pending.eventRef())
+                            && outbox.payload().equals(pending.payload())
+                            && outbox.retryState().attemptCount() == 0
+                            && outbox.retryState().maxAttempts() == 3
+                            && outbox.retryState().nextAttemptAt().equals(NOW)
+            ));
         }
     }
 
     @Nested
-    @DisplayName("claimAll()은")
-    class Describe_claimAll {
+    @DisplayName("claimPendingOutboxes()는")
+    class Describe_claimPendingOutboxes {
 
         @Test
-        @DisplayName("PENDING outbox 목록을 PROCESSING으로 전이하고 일괄 저장한다")
-        void it_claims_all_pending_outboxes() {
+        @DisplayName("조회한 PENDING outbox 목록을 PROCESSING으로 전이하고 일괄 저장한다")
+        void it_claims_pending_outboxes() {
             // given
             final List<DomainEventOutbox> pending = List.of(
                     DomainEventOutboxFixture.pending(),
                     DomainEventOutboxFixture.pendingInAppRequest()
             );
+            final int batchSize = 25;
+            given(outboxRepository.findPendingBefore(NOW, batchSize)).willReturn(pending);
             given(outboxRepository.saveAll(any())).willAnswer(inv -> inv.getArgument(0));
 
             // when
-            final List<DomainEventOutbox> result = outboxService.claimAll(pending, NOW);
+            final List<DomainEventOutbox> result = outboxService.claimPendingOutboxes(NOW, batchSize);
 
             // then
             assertThat(result).hasSize(2);
             result.forEach(o -> {
                 assertThat(o.status()).isEqualTo(OutboxStatus.PROCESSING);
                 assertThat(o.lock().lockedAt()).isEqualTo(NOW);
+                assertThat(o.retryState().attemptCount()).isZero();
             });
         }
     }
 
     @Nested
-    @DisplayName("saveAll()은")
-    class Describe_saveAll {
+    @DisplayName("saveAllProcessingResults()는")
+    class Describe_saveAllProcessingResults {
 
         @Test
-        @DisplayName("outbox 목록을 일괄 저장한다")
-        void it_saves_all_outboxes() {
+        @DisplayName("처리 결과 outbox 목록을 일괄 저장한다")
+        void it_saves_processing_results() {
             // given
             final List<DomainEventOutbox> outboxes = List.of(
-                    DomainEventOutboxFixture.processing(),
-                    DomainEventOutboxFixture.processing()
+                    DomainEventOutboxFixture.processing().complete(),
+                    DomainEventOutboxFixture.processing().fail("timeout", NOW.plusMinutes(1))
             );
-            given(outboxRepository.saveAll(any())).willAnswer(inv -> inv.getArgument(0));
+            given(outboxRepository.saveAllProcessingResults(any())).willAnswer(inv -> inv.getArgument(0));
 
             // when
-            final List<DomainEventOutbox> result = outboxService.saveAll(outboxes);
+            final List<DomainEventOutbox> result = outboxService.saveAllProcessingResults(outboxes);
 
             // then
             assertThat(result).hasSize(2);
-            verify(outboxRepository).saveAll(outboxes);
+            verify(outboxRepository).saveAllProcessingResults(outboxes);
         }
     }
 
@@ -183,26 +195,4 @@ class OutboxServiceTest {
         }
     }
 
-    @Nested
-    @DisplayName("findPendingOutboxes()는")
-    class Describe_findPendingOutboxes {
-
-        @Test
-        @DisplayName("50개 limit으로 PENDING outbox 목록을 반환한다")
-        void it_returns_pending_outboxes_with_limit() {
-            // given
-            final List<DomainEventOutbox> pending = List.of(
-                    DomainEventOutboxFixture.pending(),
-                    DomainEventOutboxFixture.pendingInAppRequest()
-            );
-            given(outboxRepository.findTop50PendingBefore(NOW)).willReturn(pending);
-
-            // when
-            final List<DomainEventOutbox> result = outboxService.findPendingOutboxes(NOW);
-
-            // then
-            assertThat(result).hasSize(2);
-            result.forEach(o -> assertThat(o.status()).isEqualTo(OutboxStatus.PENDING));
-        }
-    }
 }

--- a/notification-core/src/test/java/com/liveklass/notification/domain/DomainEventOutboxTest.java
+++ b/notification-core/src/test/java/com/liveklass/notification/domain/DomainEventOutboxTest.java
@@ -42,7 +42,7 @@ class DomainEventOutboxTest {
     class Describe_claim {
 
         @Test
-        @DisplayName("PENDING → PROCESSING으로 전이하고 lock과 attemptCount가 갱신된다")
+        @DisplayName("PENDING → PROCESSING으로 전이하고 lock만 설정된다")
         void it_transitions_to_processing() {
             // given
             final DomainEventOutbox outbox = DomainEventOutboxFixture.pending();
@@ -53,7 +53,7 @@ class DomainEventOutboxTest {
             // then
             assertThat(claimed.status()).isEqualTo(OutboxStatus.PROCESSING);
             assertThat(claimed.lock().lockedAt()).isEqualTo(NOW);
-            assertThat(claimed.retryState().attemptCount()).isEqualTo(1);
+            assertThat(claimed.retryState().attemptCount()).isZero();
         }
 
         @Test
@@ -73,7 +73,7 @@ class DomainEventOutboxTest {
     class Describe_complete {
 
         @Test
-        @DisplayName("PROCESSING → SENT로 전이한다")
+        @DisplayName("PROCESSING → SENT로 전이하고 attemptCount를 증가시킨다")
         void it_transitions_to_sent() {
             // given
             final DomainEventOutbox processing = DomainEventOutboxFixture.processing();
@@ -84,6 +84,7 @@ class DomainEventOutboxTest {
             // then
             assertThat(completed.status()).isEqualTo(OutboxStatus.SENT);
             assertThat(completed.lock().lockedAt()).isNull();
+            assertThat(completed.retryState().attemptCount()).isEqualTo(1);
         }
     }
 
@@ -92,7 +93,7 @@ class DomainEventOutboxTest {
     class Describe_fail {
 
         @Test
-        @DisplayName("재시도 가능하면 PENDING으로 돌아가고 lastError가 기록된다")
+        @DisplayName("재시도 가능하면 PENDING으로 돌아가고 attemptCount와 lastError가 기록된다")
         void it_returns_to_pending_with_error_when_retryable() {
             // given
             final DomainEventOutbox processing = DomainEventOutboxFixture.processing();
@@ -104,6 +105,7 @@ class DomainEventOutboxTest {
 
             // then
             assertThat(failed.status()).isEqualTo(OutboxStatus.PENDING);
+            assertThat(failed.retryState().attemptCount()).isEqualTo(1);
             assertThat(failed.retryState().lastError()).isEqualTo(error);
             assertThat(failed.retryState().nextAttemptAt()).isEqualTo(nextAttemptAt);
             assertThat(failed.lock().lockedAt()).isNull();
@@ -120,6 +122,7 @@ class DomainEventOutboxTest {
 
             // then
             assertThat(deadLetter.status()).isEqualTo(OutboxStatus.DEAD_LETTER);
+            assertThat(deadLetter.retryState().attemptCount()).isEqualTo(1);
             assertThat(deadLetter.retryState().lastError()).isEqualTo("fatal error");
         }
     }

--- a/notification-core/src/test/java/com/liveklass/notification/domain/RetryStateTest.java
+++ b/notification-core/src/test/java/com/liveklass/notification/domain/RetryStateTest.java
@@ -108,6 +108,48 @@ class RetryStateTest {
     }
 
     @Nested
+    @DisplayName("recordSuccess()는")
+    class Describe_record_success {
+
+        @Test
+        @DisplayName("attemptCount를 1 증가시키고 lastError를 지운다")
+        void it_increments_attempt_count_and_clears_error() {
+            // given
+            final RetryState state = new RetryState(1, 3, NOW, "temporary error");
+
+            // when
+            final RetryState success = state.recordSuccess();
+
+            // then
+            assertThat(success.attemptCount()).isEqualTo(2);
+            assertThat(success.lastError()).isNull();
+            assertThat(success.nextAttemptAt()).isEqualTo(NOW);
+        }
+    }
+
+    @Nested
+    @DisplayName("recordFailure()은")
+    class Describe_record_failure {
+
+        @Test
+        @DisplayName("attemptCount를 1 증가시키고 에러 메시지와 nextAttemptAt을 기록한다")
+        void it_increments_attempt_count_and_records_error() {
+            // given
+            final RetryState state = RetryState.initial(3, NOW);
+            final String error = "connection timeout";
+            final LocalDateTime nextAttemptAt = NOW.plusMinutes(2);
+
+            // when
+            final RetryState failed = state.recordFailure(error, nextAttemptAt);
+
+            // then
+            assertThat(failed.attemptCount()).isEqualTo(1);
+            assertThat(failed.lastError()).isEqualTo(error);
+            assertThat(failed.nextAttemptAt()).isEqualTo(nextAttemptAt);
+        }
+    }
+
+    @Nested
     @DisplayName("withFailure()은")
     class Describe_with_failure {
 

--- a/notification-core/src/test/java/com/liveklass/notification/domain/vo/ProcessingLockTest.java
+++ b/notification-core/src/test/java/com/liveklass/notification/domain/vo/ProcessingLockTest.java
@@ -91,5 +91,19 @@ class ProcessingLockTest {
             assertThat(lock.status()).isEqualTo(OutboxStatus.DEAD_LETTER);
             assertThat(lock.lockedAt()).isNull();
         }
+
+        @Test
+        @DisplayName("of(status, lockedAt)는 상태에 맞는 lock 조합을 복원한다")
+        void it_restores_lock_from_status_and_locked_at() {
+            // when
+            final ProcessingLock processing = ProcessingLock.of(OutboxStatus.PROCESSING, NOW);
+            final ProcessingLock pending = ProcessingLock.of(OutboxStatus.PENDING, NOW.plusMinutes(1));
+
+            // then
+            assertThat(processing.status()).isEqualTo(OutboxStatus.PROCESSING);
+            assertThat(processing.lockedAt()).isEqualTo(NOW);
+            assertThat(pending.status()).isEqualTo(OutboxStatus.PENDING);
+            assertThat(pending.lockedAt()).isNull();
+        }
     }
 }


### PR DESCRIPTION
## 📌 한눈에 보기

| 구분 | 내용 |
| --- | --- |
| 스키마 | `domain_event_outbox`, `in_app_notification` DDL 및 JDBC 의존성 정리 |
| 도메인 | Outbox 재시도 상태 전이, Processing 락 복원 팩토리 |
| 애플리케이션 | Outbox / InApp 포트 계약 정리 (claimPendingOutboxes, saveAllProcessingResults 등) |
| 인프라 | JPA + JDBC 이중 저장소 구현 (upsert, batchUpdate, FOR UPDATE SKIP LOCKED) |
| 테스트 | 도메인 상태 전이 / 애플리케이션 서비스 단위 테스트 |

## 🔧 상세 변경

### 1. 스키마 및 의존성
- `schema.sql`에 `domain_event_outbox`, `in_app_notification` DDL 추가
- `notification-core` build.gradle에 `spring-boot-starter-data-jpa`, `spring-boot-starter-jdbc` 추가

### 2. 도메인 계층
- `DomainEventOutbox` 재시도 상태 전이 정리 (`PENDING` → `PROCESSING` → `COMPLETED` / `FAILED` / `DEAD_LETTER`)
- `DomainEventOutbox.restoreProcessingLock()` 팩토리 메서드 추가 — Stuck 복구 스케줄러에서 사용

### 3. 애플리케이션 계약
- `OutboxRepository` 포트: `claimPendingOutboxes`, `saveAll`, `saveAllProcessingResults`, `findStuckProcessing` 분리
- `InAppNotificationRepository` 포트: `saveAll`, `existsByOutboxId` 추가
- `OutboxService.claimPendingOutboxes()` — `FOR UPDATE SKIP LOCKED` + `UPDATE PROCESSING`을 단일 `@Transactional`로 묶어 다중 인스턴스 중복 처리 방지

### 4. 인프라 계층 (JPA + JDBC 분리)

| 용도 | 기술 |
| --- | --- |
| 단건 CRUD, 상태별 조회 | JPA (`JpaOutboxRepository`, `JpaInAppNotificationRepository`) |
| `ON DUPLICATE KEY UPDATE` upsert | JDBC (`JdbcOutboxRepositoryImpl`) |
| `FOR UPDATE SKIP LOCKED` 폴링 | JDBC |
| 대량 배치 업데이트 | JDBC `batchUpdate` |

- `saveAll` (상태 가드 없음) — claim 단계 전용
- `saveAllProcessingResults` (`WHERE status = 'PROCESSING'` 가드) — 발송 결과 반영 전용, 복구 스케줄러와의 경합 방지

### 5. 테스트
- `DomainEventOutbox` 상태 전이 단위 테스트
- `OutboxService`, `InAppNotificationService` 애플리케이션 서비스 단위 테스트

## 🧪 검증

```bash
./gradlew :notification-core:test
```

## ✅ 체크리스트

- [x] 코드 작성 완료
- [x] 단위 테스트 작성
- [x] 로컬 환경 테스트

## 🔗 관련 이슈

- Closes #