### PR TITLE
notification event publisher를 core로 통합

### DIFF
--- a/notification-core/src/main/java/com/liveklass/notification/application/config/NotificationCoreConfig.java
+++ b/notification-core/src/main/java/com/liveklass/notification/application/config/NotificationCoreConfig.java
@@ -1,0 +1,9 @@
+package com.liveklass.notification.application.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(NotificationRetryProperties.class)
+public class NotificationCoreConfig {
+}

--- a/notification-core/src/main/java/com/liveklass/notification/application/config/NotificationRetryProperties.java
+++ b/notification-core/src/main/java/com/liveklass/notification/application/config/NotificationRetryProperties.java
@@ -1,0 +1,33 @@
+package com.liveklass.notification.application.config;
+
+import com.liveklass.common.event.ChannelType;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.Map;
+
+@ConfigurationProperties(prefix = "notification.retry")
+public record NotificationRetryProperties(
+        int defaultMaxAttempts,
+        Map<ChannelType, ChannelRetryPolicy> typePolicy
+) {
+    private static final long DEFAULT_BACKOFF_BASE_SECONDS = 5L;
+
+    public int maxAttempts(final ChannelType channelType) {
+        if (typePolicy != null && typePolicy.containsKey(channelType)) {
+            return typePolicy.get(channelType).maxAttempts();
+        }
+        return defaultMaxAttempts > 0 ? defaultMaxAttempts : 3;
+    }
+
+    public long backoffBaseSeconds(final ChannelType channelType) {
+        if (typePolicy != null && typePolicy.containsKey(channelType)) {
+            return typePolicy.get(channelType).backoffBaseSeconds();
+        }
+        return DEFAULT_BACKOFF_BASE_SECONDS;
+    }
+
+    public record ChannelRetryPolicy(
+            int maxAttempts,
+            long backoffBaseSeconds
+    ) {}
+}

--- a/notification-core/src/main/java/com/liveklass/notification/application/service/OutboxDomainEventPublisher.java
+++ b/notification-core/src/main/java/com/liveklass/notification/application/service/OutboxDomainEventPublisher.java
@@ -1,24 +1,21 @@
-package com.liveklass.notification.worker.producer;
+package com.liveklass.notification.application.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.liveklass.common.event.ChannelType;
 import com.liveklass.common.event.DomainEvent;
 import com.liveklass.common.event.DomainEventPublisher;
 import com.liveklass.common.event.PayloadValidator;
-import com.liveklass.notification.application.service.OutboxService;
+import com.liveklass.notification.application.config.NotificationRetryProperties;
 import com.liveklass.notification.domain.vo.IdempotencyKey;
-import com.liveklass.notification.worker.config.WorkerProperties;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
-
-@Component
+@Service
 @RequiredArgsConstructor
-public class DomainEventPublisherAdapter implements DomainEventPublisher {
+public class OutboxDomainEventPublisher implements DomainEventPublisher {
 
     private final OutboxService outboxService;
-    private final WorkerProperties workerProperties;
+    private final NotificationRetryProperties retryProperties;
 
     @Override
     public void publish(final DomainEvent event) {
@@ -33,8 +30,8 @@ public class DomainEventPublisherAdapter implements DomainEventPublisher {
                 channelType,
                 event.referenceId(),
                 payload.toString(),
-                LocalDateTime.now(),
-                workerProperties.retry().maxAttempts(channelType)
+                event.publishedAt(),
+                retryProperties.maxAttempts(channelType)
         );
     }
 }

--- a/notification-core/src/main/java/com/liveklass/notification/application/usecase/SendNotificationUseCase.java
+++ b/notification-core/src/main/java/com/liveklass/notification/application/usecase/SendNotificationUseCase.java
@@ -1,0 +1,59 @@
+package com.liveklass.notification.application.usecase;
+
+import com.liveklass.common.event.ChannelType;
+import com.liveklass.common.event.DomainEvent;
+import com.liveklass.common.event.DomainEventPublisher;
+import com.liveklass.common.event.Topic;
+import com.liveklass.notification.domain.event.EmailNotificationEvent;
+import com.liveklass.notification.domain.event.InAppNotificationEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class SendNotificationUseCase {
+
+    private final DomainEventPublisher eventPublisher;
+
+    public void send(
+            final Long recipientId,
+            final ChannelType channelType,
+            final Long referenceId,
+            final String title,
+            final String body,
+            final String subject,
+            final String recipientEmail,
+            final LocalDateTime scheduledAt
+    ) {
+        final DomainEvent event = buildEvent(
+                channelType, recipientId, String.valueOf(referenceId),
+                title, body, subject, recipientEmail, scheduledAt
+        );
+
+        eventPublisher.publish(event);
+    }
+
+    private static DomainEvent buildEvent(
+            final ChannelType channelType,
+            final Long recipientId,
+            final String referenceId,
+            final String title,
+            final String body,
+            final String subject,
+            final String recipientEmail,
+            final LocalDateTime now
+    ) {
+        return switch (channelType) {
+            case IN_APP -> new InAppNotificationEvent(
+                    Topic.IN_APP_NOTIFICATION_REQUEST, recipientId, referenceId,
+                    title, body, now != null ? now : LocalDateTime.now()
+            );
+            case EMAIL -> new EmailNotificationEvent(
+                    Topic.EMAIL_NOTIFICATION_REQUEST, recipientId, referenceId,
+                    subject, body, recipientEmail, now != null ? now : LocalDateTime.now()
+            );
+        };
+    }
+}

--- a/notification-core/src/main/resources/application.yml
+++ b/notification-core/src/main/resources/application.yml
@@ -1,0 +1,10 @@
+notification:
+  retry:
+    default-max-attempts: 3
+    type-policy:
+      EMAIL:
+        max-attempts: 6
+        backoff-base-seconds: 30
+      IN_APP:
+        max-attempts: 3
+        backoff-base-seconds: 5

--- a/notification-core/src/test/java/com/liveklass/notification/application/service/OutboxDomainEventPublisherTest.java
+++ b/notification-core/src/test/java/com/liveklass/notification/application/service/OutboxDomainEventPublisherTest.java
@@ -1,12 +1,12 @@
-package com.liveklass.notification.worker.producer;
+package com.liveklass.notification.application.service;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.liveklass.common.event.ChannelType;
 import com.liveklass.common.event.DomainEvent;
 import com.liveklass.common.event.Topic;
-import com.liveklass.notification.application.service.OutboxService;
+import com.liveklass.notification.application.config.NotificationRetryProperties;
 import com.liveklass.notification.domain.event.EmailNotificationEvent;
-import com.liveklass.notification.worker.config.WorkerProperties;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -22,28 +22,31 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @Tag("UNIT_TEST")
 @ExtendWith(MockitoExtension.class)
-@DisplayName("DomainEventPublisherAdapter는")
-class DomainEventPublisherAdapterTest {
-
-    private static final LocalDateTime NOW = LocalDateTime.of(2026, 4, 24, 12, 0);
+@DisplayName("OutboxDomainEventPublisher는")
+class OutboxDomainEventPublisherTest {
 
     @Mock
     private OutboxService outboxService;
 
     @Test
-    @DisplayName("channelType 최소 계약을 만족하면 outbox를 저장한다")
-    void it_saves_outbox_when_payload_is_valid() {
+    @DisplayName("채널별 재시도 설정과 event.publishedAt을 사용해 outbox를 저장한다")
+    void it_saves_outbox_with_channel_retry_policy_and_published_at() {
         // given
-        final DomainEventPublisherAdapter adapter = new DomainEventPublisherAdapter(
+        final LocalDateTime publishedAt = LocalDateTime.of(2026, 4, 24, 12, 0);
+        final OutboxDomainEventPublisher publisher = new OutboxDomainEventPublisher(
                 outboxService,
-                new WorkerProperties(
-                        new WorkerProperties.PollingProperties(true, 1000L, 50, 5L),
-                        new WorkerProperties.RetryProperties(3, Map.of())
+                new NotificationRetryProperties(
+                        3,
+                        Map.of(
+                                ChannelType.EMAIL,
+                                new NotificationRetryProperties.ChannelRetryPolicy(6, 30)
+                        )
                 )
         );
         final EmailNotificationEvent event = new EmailNotificationEvent(
@@ -53,11 +56,11 @@ class DomainEventPublisherAdapterTest {
                 "결제 완료",
                 "49,000원이 결제되었습니다.",
                 "user@example.com",
-                NOW
+                publishedAt
         );
 
         // when
-        adapter.publish(event);
+        publisher.publish(event);
 
         // then
         verify(outboxService).createOutbox(
@@ -65,37 +68,27 @@ class DomainEventPublisherAdapterTest {
                 anyLong(),
                 anyLong(),
                 any(Topic.class),
-                any(com.liveklass.common.event.ChannelType.class),
+                any(ChannelType.class),
                 anyString(),
                 anyString(),
-                any(LocalDateTime.class),
-                anyInt()
+                eq(publishedAt),
+                eq(6)
         );
     }
 
     @Test
-    @DisplayName("channelType 최소 계약을 만족하지 않으면 outbox를 저장하지 않는다")
+    @DisplayName("payload 최소 계약을 만족하지 않으면 outbox를 저장하지 않는다")
     void it_does_not_save_outbox_when_payload_is_invalid() {
         // given
-        final DomainEventPublisherAdapter adapter = new DomainEventPublisherAdapter(
+        final LocalDateTime publishedAt = LocalDateTime.of(2026, 4, 24, 12, 0);
+        final OutboxDomainEventPublisher publisher = new OutboxDomainEventPublisher(
                 outboxService,
-                new WorkerProperties(
-                        new WorkerProperties.PollingProperties(true, 1000L, 50, 5L),
-                        new WorkerProperties.RetryProperties(3, Map.of())
-                )
+                new NotificationRetryProperties(3, Map.of())
         );
         final DomainEvent event = new DomainEvent() {
             @Override
             public Topic topic() {
                 return Topic.IN_APP_NOTIFICATION_REQUEST;
-            }
-
-            @Override
-            public com.fasterxml.jackson.databind.JsonNode payload() {
-                final ObjectNode payload = JsonNodeFactory.instance.objectNode();
-                payload.put("title", " ");
-                payload.put("body", "본문");
-                return payload;
             }
 
             @Override
@@ -110,20 +103,28 @@ class DomainEventPublisherAdapterTest {
 
             @Override
             public LocalDateTime publishedAt() {
-                return NOW;
+                return publishedAt;
+            }
+
+            @Override
+            public com.fasterxml.jackson.databind.JsonNode payload() {
+                final ObjectNode payload = JsonNodeFactory.instance.objectNode();
+                payload.put("title", " ");
+                payload.put("body", "본문");
+                return payload;
             }
         };
 
         // when & then
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> adapter.publish(event))
+                .isThrownBy(() -> publisher.publish(event))
                 .withMessageContaining("title");
         verify(outboxService, never()).createOutbox(
                 anyString(),
                 anyLong(),
                 anyLong(),
                 any(Topic.class),
-                any(com.liveklass.common.event.ChannelType.class),
+                any(ChannelType.class),
                 anyString(),
                 anyString(),
                 any(LocalDateTime.class),

--- a/notification-core/src/test/java/com/liveklass/notification/application/usecase/SendNotificationUseCaseTest.java
+++ b/notification-core/src/test/java/com/liveklass/notification/application/usecase/SendNotificationUseCaseTest.java
@@ -1,0 +1,85 @@
+package com.liveklass.notification.application.usecase;
+
+import com.liveklass.common.event.ChannelType;
+import com.liveklass.common.event.DomainEvent;
+import com.liveklass.common.event.DomainEventPublisher;
+import com.liveklass.notification.domain.event.EmailNotificationEvent;
+import com.liveklass.notification.domain.event.InAppNotificationEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@Tag("UNIT_TEST")
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SendNotificationUseCase는")
+class SendNotificationUseCaseTest {
+
+    @InjectMocks
+    private SendNotificationUseCase sendNotificationUseCase;
+
+    @Mock
+    private DomainEventPublisher eventPublisher;
+
+    @Test
+    @DisplayName("예약 시각이 있으면 event.publishedAt에 그대로 담아 발행한다")
+    void it_publishes_event_with_scheduled_at() {
+        // given
+        final LocalDateTime scheduledAt = LocalDateTime.of(2026, 4, 25, 9, 0);
+
+        // when
+        sendNotificationUseCase.send(
+                1L,
+                ChannelType.EMAIL,
+                100L,
+                null,
+                "결제가 완료되었습니다.",
+                "결제 완료",
+                "user@example.com",
+                scheduledAt
+        );
+
+        // then
+        final ArgumentCaptor<DomainEvent> captor = ArgumentCaptor.forClass(DomainEvent.class);
+        verify(eventPublisher).publish(captor.capture());
+        final DomainEvent published = captor.getValue();
+        assertThat(published).isInstanceOf(EmailNotificationEvent.class);
+        assertThat(published.publishedAt()).isEqualTo(scheduledAt);
+    }
+
+    @Test
+    @DisplayName("예약 시각이 없으면 현재 시각 기반 이벤트를 발행한다")
+    void it_publishes_event_with_now_when_schedule_is_missing() {
+        // given
+        final LocalDateTime before = LocalDateTime.now();
+
+        // when
+        sendNotificationUseCase.send(
+                1L,
+                ChannelType.IN_APP,
+                100L,
+                "수강 신청 완료",
+                "Spring Boot 수강 신청이 완료되었습니다.",
+                null,
+                null,
+                null
+        );
+        final LocalDateTime after = LocalDateTime.now();
+
+        // then
+        final ArgumentCaptor<DomainEvent> captor = ArgumentCaptor.forClass(DomainEvent.class);
+        verify(eventPublisher).publish(captor.capture());
+        final DomainEvent published = captor.getValue();
+        assertThat(published).isInstanceOf(InAppNotificationEvent.class);
+        assertThat(published.publishedAt()).isBetween(before, after);
+    }
+}

--- a/notification-worker/src/main/java/com/liveklass/notification/worker/config/WorkerProperties.java
+++ b/notification-worker/src/main/java/com/liveklass/notification/worker/config/WorkerProperties.java
@@ -1,46 +1,12 @@
 package com.liveklass.notification.worker.config;
 
-import com.liveklass.common.event.ChannelType;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-import java.util.Map;
-
-@ConfigurationProperties(prefix = "notification")
+@ConfigurationProperties(prefix = "notification.polling")
 public record WorkerProperties(
-        PollingProperties polling,
-        RetryProperties retry
+        boolean enabled,
+        long fixedDelayMs,
+        int batchSize,
+        long stuckThresholdMinutes
 ) {
-
-    public record PollingProperties(
-            boolean enabled,
-            long fixedDelayMs,
-            int batchSize,
-            long stuckThresholdMinutes
-    ) {}
-
-    public record RetryProperties(
-            int defaultMaxAttempts,
-            Map<ChannelType, ChannelRetryPolicy> typePolicy
-    ) {
-        private static final long DEFAULT_BACKOFF_BASE_SECONDS = 5L;
-
-        public int maxAttempts(final ChannelType channelType) {
-            if (typePolicy != null && typePolicy.containsKey(channelType)) {
-                return typePolicy.get(channelType).maxAttempts();
-            }
-            return defaultMaxAttempts;
-        }
-
-        public long backoffBaseSeconds(final ChannelType channelType) {
-            if (typePolicy != null && typePolicy.containsKey(channelType)) {
-                return typePolicy.get(channelType).backoffBaseSeconds();
-            }
-            return DEFAULT_BACKOFF_BASE_SECONDS;
-        }
-
-        public record ChannelRetryPolicy(
-                int maxAttempts,
-                long backoffBaseSeconds
-        ) {}
-    }
 }

--- a/notification-worker/src/main/java/com/liveklass/notification/worker/consumer/OutboxPollingScheduler.java
+++ b/notification-worker/src/main/java/com/liveklass/notification/worker/consumer/OutboxPollingScheduler.java
@@ -23,13 +23,13 @@ public class OutboxPollingScheduler {
 
     @Scheduled(fixedDelayString = "${notification.polling.fixed-delay-ms:1000}")
     public void poll() {
-        if (!workerProperties.polling().enabled()) {
+        if (!workerProperties.enabled()) {
             return;
         }
 
         final LocalDateTime now = LocalDateTime.now();
         final List<DomainEventOutbox> claimed = outboxService.claimPendingOutboxes(
-                now, workerProperties.polling().batchSize());
+                now, workerProperties.batchSize());
         if (claimed.isEmpty()) {
             return;
         }

--- a/notification-worker/src/main/java/com/liveklass/notification/worker/consumer/policy/BackoffPolicy.java
+++ b/notification-worker/src/main/java/com/liveklass/notification/worker/consumer/policy/BackoffPolicy.java
@@ -1,7 +1,7 @@
 package com.liveklass.notification.worker.consumer.policy;
 
 import com.liveklass.common.event.ChannelType;
-import com.liveklass.notification.worker.config.WorkerProperties;
+import com.liveklass.notification.application.config.NotificationRetryProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -11,10 +11,10 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class BackoffPolicy {
 
-    private final WorkerProperties workerProperties;
+    private final NotificationRetryProperties retryProperties;
 
     public LocalDateTime nextAttemptAt(final ChannelType channelType, final int attemptCount, final LocalDateTime now) {
-        final long baseSeconds = workerProperties.retry().backoffBaseSeconds(channelType);
+        final long baseSeconds = retryProperties.backoffBaseSeconds(channelType);
         final long base = baseSeconds * (1L << Math.max(0, attemptCount - 1));
         final long jitterSeconds = (long) (base * (Math.random() * 0.4 - 0.2));
         return now.plusSeconds(base + jitterSeconds);

--- a/notification-worker/src/main/java/com/liveklass/notification/worker/recovery/StuckOutboxRecoveryScheduler.java
+++ b/notification-worker/src/main/java/com/liveklass/notification/worker/recovery/StuckOutboxRecoveryScheduler.java
@@ -39,7 +39,7 @@ public class StuckOutboxRecoveryScheduler {
 
     @Scheduled(fixedDelay = 60_000)
     public void recover() {
-        final long stuckThresholdMinutes = workerProperties.polling().stuckThresholdMinutes();
+        final long stuckThresholdMinutes = workerProperties.stuckThresholdMinutes();
         final LocalDateTime now = LocalDateTime.now();
         final LocalDateTime lockedBefore = now.minusMinutes(stuckThresholdMinutes);
 

--- a/notification-worker/src/main/resources/application.yml
+++ b/notification-worker/src/main/resources/application.yml
@@ -18,12 +18,3 @@ notification:
     fixed-delay-ms: 1000
     batch-size: 50
     stuck-threshold-minutes: 5
-  retry:
-    default-max-attempts: 3
-    type-policy:
-      EMAIL:
-        max-attempts: 6
-        backoff-base-seconds: 30
-      IN_APP:
-        max-attempts: 3
-        backoff-base-seconds: 5

--- a/notification-worker/src/test/java/com/liveklass/notification/worker/consumer/OutboxPollingSchedulerTest.java
+++ b/notification-worker/src/test/java/com/liveklass/notification/worker/consumer/OutboxPollingSchedulerTest.java
@@ -14,7 +14,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -36,10 +35,7 @@ class OutboxPollingSchedulerTest {
     @DisplayName("설정된 batch size로 outbox를 claim하고 처리 결과 저장 메서드를 호출한다")
     void it_claims_with_configured_batch_size_and_saves_processing_results() {
         // given
-        final WorkerProperties workerProperties = new WorkerProperties(
-                new WorkerProperties.PollingProperties(true, 1000L, 25, 5L),
-                new WorkerProperties.RetryProperties(3, Map.of())
-        );
+        final WorkerProperties workerProperties = new WorkerProperties(true, 1000L, 25, 5L);
         final OutboxPollingScheduler scheduler =
                 new OutboxPollingScheduler(outboxService, outboxDispatcher, workerProperties);
         final List<DomainEventOutbox> claimed = List.of(DomainEventOutboxFixture.processing());

--- a/notification-worker/src/test/java/com/liveklass/notification/worker/recovery/StuckOutboxRecoverySchedulerTest.java
+++ b/notification-worker/src/test/java/com/liveklass/notification/worker/recovery/StuckOutboxRecoverySchedulerTest.java
@@ -50,10 +50,7 @@ class StuckOutboxRecoverySchedulerTest {
         scheduler = new StuckOutboxRecoveryScheduler(
                 List.of(inAppVerifier, emailVerifier),
                 outboxService,
-                new WorkerProperties(
-                        new WorkerProperties.PollingProperties(true, 1000L, 50, 5L),
-                        new WorkerProperties.RetryProperties(3, java.util.Map.of())
-                )
+                new WorkerProperties(true, 1000L, 50, 5L)
         );
     }
 


### PR DESCRIPTION
## 📌 한눈에 보기

| 구분 | 내용 |
| --- | --- |
| 구조 | `DomainEventPublisher` outbox 구현을 `notification-core`로 통합 |
| 설정 | `notification.retry` 기본 설정을 `notification-core`로 이동 |
| 동작 | `publishedAt`을 outbox `nextAttemptAt`으로 사용하도록 정리 |
| 검증 | `./gradlew :notification-core:test :notification-worker:test --no-daemon` |

## 🔧 상세 변경

### 1. notification-core로 event publisher 통합
- `OutboxDomainEventPublisher`를 `notification-core`로 이동해 payload 검증, 멱등키 생성, outbox 저장 정책을 한 곳으로 통합
- `SendNotificationUseCase`가 직접 outbox를 다루지 않고 `publish(event)`만 호출하도록 정리
- 예약 발송 시 `scheduledAt`을 이벤트 `publishedAt`으로 담아 outbox `nextAttemptAt`과 동일하게 사용하도록 정리

### 2. retry 설정 공통화
- `NotificationRetryProperties`, `NotificationCoreConfig` 추가로 `notification.retry` 바인딩을 core 공통 설정으로 이동
- `notification-core` 리소스에 retry 기본값을 정의하고 `liveklass-api`, `notification-worker`의 중복 설정 제거
- worker `BackoffPolicy`가 공통 retry 설정을 사용하도록 연결

### 3. worker polling 설정 단순화
- `WorkerProperties`를 `notification.polling` 전용으로 축소
- polling scheduler, stuck recovery scheduler, 관련 테스트를 새 설정 구조에 맞게 정리
- worker 전용 `DomainEventPublisherAdapter`와 테스트 제거

## 🧪 검증
- `./gradlew :notification-core:test :notification-worker:test --no-daemon`

## ✅ 체크리스트
- [x] core event publisher 통합
- [x] retry 설정 공통화
- [x] worker polling 설정 정리
- [x] 단위 테스트 검증
