### PR TITLE
api layer 엔드포인트 추가

### DIFF
--- a/liveklass-api/build.gradle
+++ b/liveklass-api/build.gradle
@@ -3,9 +3,12 @@ plugins {
 }
 
 dependencies {
+	implementation project(':liveklass-common')
 	implementation project(':notification-core')
 	implementation project(':lecture-core')
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 }
 
 bootJar {

--- a/liveklass-api/src/main/java/com/liveklass/common/dto/ErrorResponse.java
+++ b/liveklass-api/src/main/java/com/liveklass/common/dto/ErrorResponse.java
@@ -1,0 +1,11 @@
+package com.liveklass.common.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "오류 응답")
+public record ErrorResponse(
+        @Schema(description = "오류 코드", example = "ENROLLMENT_012")
+        String errorCode,
+        @Schema(description = "오류 메시지", example = "이미 수강 신청한 강의입니다.")
+        String message
+) {}

--- a/liveklass-api/src/main/java/com/liveklass/common/exception/GlobalExceptionHandler.java
+++ b/liveklass-api/src/main/java/com/liveklass/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,73 @@
+package com.liveklass.common.exception;
+
+import com.liveklass.common.dto.ErrorResponse;
+import com.liveklass.common.error.exception.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ErrorResponse> handleBadRequest(final BadRequestException e) {
+        return ResponseEntity.badRequest().body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotFound(final NotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<ErrorResponse> handleConflict(final ConflictException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ErrorResponse> handleForbidden(final ForbiddenException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ErrorResponse> handleUnauthorized(final UnauthorizedException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(ServiceUnavailableException.class)
+    public ResponseEntity<ErrorResponse> handleServiceUnavailable(final ServiceUnavailableException e) {
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(InternalServerErrorException.class)
+    public ResponseEntity<ErrorResponse> handleInternalServerError(final InternalServerErrorException e) {
+        log.error("[GlobalExceptionHandler] internal error: {}", e.getErrorLog(), e);
+        return ResponseEntity.internalServerError()
+                .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(final MethodArgumentNotValidException e) {
+        final String message = e.getBindingResult().getFieldErrors().stream()
+                .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                .findFirst()
+                .orElse("요청 값이 올바르지 않습니다.");
+        return ResponseEntity.badRequest().body(new ErrorResponse("VALIDATION_ERROR", message));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnexpected(final Exception e) {
+        log.error("[GlobalExceptionHandler] unexpected error", e);
+        return ResponseEntity.internalServerError()
+                .body(new ErrorResponse("INTERNAL_ERROR", "서버 오류가 발생했습니다."));
+    }
+}

--- a/liveklass-api/src/main/java/com/liveklass/enrollment/api/EnrollmentApi.java
+++ b/liveklass-api/src/main/java/com/liveklass/enrollment/api/EnrollmentApi.java
@@ -1,0 +1,49 @@
+package com.liveklass.enrollment.api;
+
+import com.liveklass.common.dto.ErrorResponse;
+import com.liveklass.enrollment.request.EnrollmentCancelRequest;
+import com.liveklass.enrollment.request.EnrollmentRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Enrollment", description = "수강 신청 API")
+@RequestMapping("/api/enrollments")
+public interface EnrollmentApi {
+
+    @Operation(summary = "수강 신청",
+            description = "강의에 수강 신청합니다. 중복 신청 시 409 오류가 발생합니다.")
+    @ApiResponse(responseCode = "201", description = "수강 신청 완료")
+    @ApiResponse(responseCode = "400", description = "요청 값 오류",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    @ApiResponse(responseCode = "404", description = "강의 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    @ApiResponse(responseCode = "409", description = "이미 수강 신청된 강의",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    void enroll(
+            @Parameter(description = "수강생 ID") @RequestHeader("X-User-Id") Long userId,
+            @Valid @RequestBody EnrollmentRequest request
+    );
+
+    @Operation(summary = "수강 취소",
+            description = "수강 신청을 취소합니다.")
+    @ApiResponse(responseCode = "200", description = "수강 취소 완료")
+    @ApiResponse(responseCode = "403", description = "본인 수강 신청 아님",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    @ApiResponse(responseCode = "404", description = "수강 신청 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    @DeleteMapping("/{enrollmentId}")
+    void cancel(
+            @Parameter(description = "수강 신청 ID") @PathVariable Long enrollmentId,
+            @Parameter(description = "수강생 ID") @RequestHeader("X-User-Id") Long userId,
+            @RequestBody(required = false) EnrollmentCancelRequest request
+    );
+}

--- a/liveklass-api/src/main/java/com/liveklass/enrollment/controller/EnrollmentController.java
+++ b/liveklass-api/src/main/java/com/liveklass/enrollment/controller/EnrollmentController.java
@@ -1,0 +1,28 @@
+package com.liveklass.enrollment.controller;
+
+import com.liveklass.enrollment.api.EnrollmentApi;
+import com.liveklass.enrollment.request.EnrollmentCancelRequest;
+import com.liveklass.enrollment.request.EnrollmentRequest;
+import com.liveklass.lecture.application.service.EnrollmentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequiredArgsConstructor
+public class EnrollmentController implements EnrollmentApi {
+
+    private final EnrollmentService enrollmentService;
+
+    @Override
+    public void enroll(final Long userId, final EnrollmentRequest request) {
+        enrollmentService.enroll(request.lectureId(), userId, LocalDateTime.now());
+    }
+
+    @Override
+    public void cancel(final Long enrollmentId, final Long userId, final EnrollmentCancelRequest request) {
+        final String cancelReason = request != null ? request.cancelReason() : null;
+        enrollmentService.cancel(enrollmentId, userId, cancelReason, LocalDateTime.now());
+    }
+}

--- a/liveklass-api/src/main/java/com/liveklass/enrollment/request/EnrollmentCancelRequest.java
+++ b/liveklass-api/src/main/java/com/liveklass/enrollment/request/EnrollmentCancelRequest.java
@@ -1,0 +1,10 @@
+package com.liveklass.enrollment.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "수강 취소 요청")
+public record EnrollmentCancelRequest(
+
+        @Schema(description = "취소 사유", example = "개인 사정으로 인한 취소")
+        String cancelReason
+) {}

--- a/liveklass-api/src/main/java/com/liveklass/enrollment/request/EnrollmentRequest.java
+++ b/liveklass-api/src/main/java/com/liveklass/enrollment/request/EnrollmentRequest.java
@@ -1,0 +1,11 @@
+package com.liveklass.enrollment.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "수강 신청 요청")
+public record EnrollmentRequest(
+
+        @Schema(description = "강의 ID", example = "1")
+        @NotNull Long lectureId
+) {}

--- a/liveklass-api/src/main/java/com/liveklass/notification/api/InAppNotificationApi.java
+++ b/liveklass-api/src/main/java/com/liveklass/notification/api/InAppNotificationApi.java
@@ -1,0 +1,40 @@
+package com.liveklass.notification.api;
+
+import com.liveklass.common.dto.ErrorResponse;
+import com.liveklass.notification.response.InAppNotificationResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "InAppNotification", description = "인앱 알림 API")
+@RequestMapping("/api/in-app-notifications")
+public interface InAppNotificationApi {
+
+    @Operation(summary = "인앱 알림 목록 조회",
+            description = "수신자 기준 인앱 알림 목록을 조회합니다. isRead 파라미터로 읽음/안읽음을 필터링할 수 있습니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping
+    List<InAppNotificationResponse> list(
+            @Parameter(description = "수신자 ID") @RequestHeader("X-User-Id") Long recipientId,
+            @Parameter(description = "읽음 여부 필터 (생략 시 전체)") @RequestParam boolean isRead
+    );
+
+    @Operation(summary = "인앱 알림 읽음 처리",
+            description = "특정 알림을 읽음 상태로 변경합니다.")
+    @ApiResponse(responseCode = "200", description = "읽음 처리 완료")
+    @ApiResponse(responseCode = "403", description = "본인 알림 아님",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    @ApiResponse(responseCode = "404", description = "알림 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    @PatchMapping("/{id}/read")
+    void markAsRead(
+            @Parameter(description = "알림 ID") @PathVariable Long id,
+            @Parameter(description = "수신자 ID") @RequestHeader("X-User-Id") Long userId
+    );
+}

--- a/liveklass-api/src/main/java/com/liveklass/notification/api/NotificationApi.java
+++ b/liveklass-api/src/main/java/com/liveklass/notification/api/NotificationApi.java
@@ -1,0 +1,47 @@
+package com.liveklass.notification.api;
+
+import com.liveklass.common.dto.ErrorResponse;
+import com.liveklass.notification.request.NotificationSendRequest;
+import com.liveklass.notification.response.NotificationStatusResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Notification", description = "알림 발송 API")
+@RequestMapping("/api/notifications")
+public interface NotificationApi {
+
+    @Operation(summary = "알림 발송 요청",
+            description = "IN_APP 또는 EMAIL 알림 발송을 비동기로 요청합니다. 즉시 발송되지 않으며 outbox를 통해 처리됩니다.")
+    @ApiResponse(responseCode = "202", description = "요청 접수 완료")
+    @ApiResponse(responseCode = "400", description = "요청 값 오류",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    @PostMapping
+    void send(@Valid @RequestBody NotificationSendRequest request);
+
+    @Operation(summary = "알림 처리 상태 조회",
+            description = "알림 요청 ID로 현재 처리 상태(대기중/처리중/발송완료/최종실패)를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiResponse(responseCode = "404", description = "알림 요청 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    @GetMapping("/{id}")
+    NotificationStatusResponse getStatus(
+            @Parameter(description = "알림 요청 ID") @PathVariable Long id,
+            @Parameter(description = "요청자 ID") @RequestHeader("X-User-Id") Long requesterId
+    );
+
+    @Operation(summary = "최종 실패 알림 수동 재시도",
+            description = "DEAD_LETTER 상태의 알림을 대기 상태로 전환해 재처리를 예약합니다. 재시도 횟수는 초기화됩니다.")
+    @ApiResponse(responseCode = "200", description = "재시도 예약 완료")
+    @ApiResponse(responseCode = "404", description = "알림 요청 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    @PostMapping("/{id}/retry")
+    void manualRetry(@Parameter(description = "알림 요청 ID") @PathVariable Long id);
+}

--- a/liveklass-api/src/main/java/com/liveklass/notification/controller/InAppNotificationController.java
+++ b/liveklass-api/src/main/java/com/liveklass/notification/controller/InAppNotificationController.java
@@ -1,0 +1,29 @@
+package com.liveklass.notification.controller;
+
+import com.liveklass.notification.api.InAppNotificationApi;
+import com.liveklass.notification.application.service.InAppNotificationService;
+import com.liveklass.notification.response.InAppNotificationResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class InAppNotificationController implements InAppNotificationApi {
+
+    private final InAppNotificationService inAppNotificationService;
+
+    @Override
+    public List<InAppNotificationResponse> list(final Long recipientId, final boolean isRead) {
+        return inAppNotificationService.findAllByRecipientId(recipientId, isRead)
+                .stream()
+                .map(InAppNotificationResponse::from)
+                .toList();
+    }
+
+    @Override
+    public void markAsRead(final Long id, final Long userId) {
+        inAppNotificationService.markAsRead(id, userId);
+    }
+}

--- a/liveklass-api/src/main/java/com/liveklass/notification/controller/NotificationController.java
+++ b/liveklass-api/src/main/java/com/liveklass/notification/controller/NotificationController.java
@@ -1,0 +1,43 @@
+package com.liveklass.notification.controller;
+
+import com.liveklass.notification.api.NotificationApi;
+import com.liveklass.notification.application.service.OutboxService;
+import com.liveklass.notification.application.usecase.SendNotificationUseCase;
+import com.liveklass.notification.request.NotificationSendRequest;
+import com.liveklass.notification.response.NotificationStatusResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class NotificationController implements NotificationApi {
+
+    private final SendNotificationUseCase sendNotificationUseCase;
+    private final OutboxService outboxService;
+
+    @Override
+    public void send(final NotificationSendRequest request) {
+        sendNotificationUseCase.send(
+                request.recipientId(),
+                request.channelType(),
+                request.referenceId(),
+                request.title(),
+                request.body(),
+                request.subject(),
+                request.recipientEmail(),
+                request.scheduledAt()
+        );
+    }
+
+    @Override
+    public NotificationStatusResponse getStatus(final Long id, final Long requesterId) {
+        return NotificationStatusResponse.from(
+                outboxService.findRequestNotificationById(id, requesterId)
+        );
+    }
+
+    @Override
+    public void manualRetry(final Long id) {
+        outboxService.manualRetry(id);
+    }
+}

--- a/liveklass-api/src/main/java/com/liveklass/notification/request/NotificationSendRequest.java
+++ b/liveklass-api/src/main/java/com/liveklass/notification/request/NotificationSendRequest.java
@@ -1,0 +1,36 @@
+package com.liveklass.notification.request;
+
+import com.liveklass.common.event.ChannelType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "알림 발송 요청")
+public record NotificationSendRequest(
+
+        @Schema(description = "수신자 ID", example = "100")
+        @NotNull Long recipientId,
+
+        @Schema(description = "발송 채널 (IN_APP | EMAIL)", example = "IN_APP")
+        @NotNull ChannelType channelType,
+
+        @Schema(description = "참조 ID (엔티티 식별자)", example = "1")
+        @NotNull Long referenceId,
+
+        @Schema(description = "알림 제목 (IN_APP 필수)", example = "수강 신청이 완료되었습니다")
+        String title,
+
+        @Schema(description = "알림 본문 (공통 필수)", example = "Spring Boot 실전 강의 수강이 완료되었습니다.")
+        @NotBlank String body,
+
+        @Schema(description = "이메일 제목 (EMAIL 필수)", example = "결제가 완료되었습니다")
+        String subject,
+
+        @Schema(description = "수신자 이메일 (EMAIL 필수)", example = "user@example.com")
+        String recipientEmail,
+
+        @Schema(description = "발송 예약 시각 (생략 시 즉시 발송)", example = "2026-04-25T09:00:00")
+        LocalDateTime scheduledAt
+) {}

--- a/liveklass-api/src/main/java/com/liveklass/notification/response/InAppNotificationResponse.java
+++ b/liveklass-api/src/main/java/com/liveklass/notification/response/InAppNotificationResponse.java
@@ -1,0 +1,39 @@
+package com.liveklass.notification.response;
+
+import com.liveklass.notification.domain.InAppNotification;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "인앱 알림 응답")
+public record InAppNotificationResponse(
+
+        @Schema(description = "알림 ID", example = "1")
+        Long id,
+
+        @Schema(description = "알림 제목", example = "수강 신청이 완료되었습니다")
+        String title,
+
+        @Schema(description = "알림 본문", example = "Spring Boot 실전 강의 수강이 완료되었습니다.")
+        String body,
+
+        @Schema(description = "읽음 여부", example = "false")
+        boolean isRead,
+
+        @Schema(description = "발행 시각")
+        LocalDateTime publishedAt,
+
+        @Schema(description = "생성 시각")
+        LocalDateTime createdAt
+) {
+    public static InAppNotificationResponse from(final InAppNotification notification) {
+        return new InAppNotificationResponse(
+                notification.id().id(),
+                notification.title(),
+                notification.body(),
+                notification.isRead(),
+                notification.publishedAt(),
+                notification.createdAt()
+        );
+    }
+}

--- a/liveklass-api/src/main/java/com/liveklass/notification/response/NotificationStatusResponse.java
+++ b/liveklass-api/src/main/java/com/liveklass/notification/response/NotificationStatusResponse.java
@@ -1,0 +1,62 @@
+package com.liveklass.notification.response;
+
+import com.liveklass.notification.domain.DomainEventOutbox;
+import com.liveklass.notification.domain.enums.OutboxStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "알림 처리 상태 응답")
+public record NotificationStatusResponse(
+
+        @Schema(description = "알림 요청 ID", example = "1")
+        Long id,
+
+        @Schema(description = "토픽", example = "IN_APP_NOTIFICATION_REQUEST")
+        String topic,
+
+        @Schema(description = "발송 채널", example = "IN_APP")
+        String channelType,
+
+        @Schema(description = "참조 ID", example = "1")
+        String referenceId,
+
+        @Schema(description = "현재 상태", example = "발송완료",
+                allowableValues = {"대기중", "처리중", "발송완료", "최종실패"})
+        String status,
+
+        @Schema(description = "시도 횟수", example = "1")
+        int attemptCount,
+
+        @Schema(description = "최대 시도 횟수", example = "3")
+        int maxAttempts,
+
+        @Schema(description = "다음 시도 예정 시각")
+        LocalDateTime nextAttemptAt,
+
+        @Schema(description = "마지막 오류 내용")
+        String lastError
+) {
+    public static NotificationStatusResponse from(final DomainEventOutbox outbox) {
+        return new NotificationStatusResponse(
+                outbox.id().id(),
+                outbox.eventRef().topic().name(),
+                outbox.eventRef().channelType().name(),
+                outbox.eventRef().referenceId(),
+                toDisplayStatus(outbox.status()),
+                outbox.retryState().attemptCount(),
+                outbox.retryState().maxAttempts(),
+                outbox.retryState().nextAttemptAt(),
+                outbox.retryState().lastError()
+        );
+    }
+
+    private static String toDisplayStatus(final OutboxStatus status) {
+        return switch (status) {
+            case PENDING -> "대기중";
+            case PROCESSING -> "처리중";
+            case SENT -> "발송완료";
+            case DEAD_LETTER -> "최종실패";
+        };
+    }
+}

--- a/notification-core/src/main/java/com/liveklass/notification/application/service/InAppNotificationService.java
+++ b/notification-core/src/main/java/com/liveklass/notification/application/service/InAppNotificationService.java
@@ -38,10 +38,12 @@ public class InAppNotificationService {
     }
 
     @Transactional
-    public void markAsRead(final Long notificationId) {
+    public void markAsRead(final Long notificationId, final Long userId) {
         final InAppNotification notification = notificationRepository.findById(new NotificationId(notificationId))
                 .orElseThrow(() -> ExceptionCreator.create(NotificationException.NOTIFICATION_NOT_FOUND,
                         "notificationId: " + notificationId));
+
+        notification.validateRecipient(userId);
 
         notificationRepository.save(notification.markRead());
     }

--- a/notification-core/src/main/java/com/liveklass/notification/application/service/OutboxService.java
+++ b/notification-core/src/main/java/com/liveklass/notification/application/service/OutboxService.java
@@ -76,6 +76,14 @@ public class OutboxService {
         return outbox;
     }
 
+    @Transactional
+    public void manualRetry(final Long outboxId) {
+        final DomainEventOutbox outbox = outboxRepository.findById(new OutboxId(outboxId))
+                .orElseThrow(() -> ExceptionCreator.create(OutboxException.OUTBOX_NOT_FOUND,
+                        "outboxId: " + outboxId));
+        outboxRepository.save(outbox.recover(LocalDateTime.now()));
+    }
+
     @Transactional(readOnly = true)
     public List<DomainEventOutbox> findStuckOutboxes(final LocalDateTime lockedBefore) {
         return outboxRepository.findStuckProcessing(lockedBefore);

--- a/notification-core/src/test/java/com/liveklass/notification/application/service/InAppNotificationServiceTest.java
+++ b/notification-core/src/test/java/com/liveklass/notification/application/service/InAppNotificationServiceTest.java
@@ -92,11 +92,12 @@ class InAppNotificationServiceTest {
         void it_marks_notification_as_read() {
             // given
             final Long notificationId = 1L;
-            final InAppNotification unread = InAppNotificationFixture.unread();
+            final Long recipientId = 1L;
+            final InAppNotification unread = InAppNotificationFixture.unread(10L, recipientId);
             given(notificationRepository.findById(new NotificationId(notificationId))).willReturn(Optional.of(unread));
 
             // when
-            notificationService.markAsRead(notificationId);
+            notificationService.markAsRead(notificationId, recipientId);
 
             // then
             verify(notificationRepository).save(argThat(InAppNotification::isRead));
@@ -111,7 +112,7 @@ class InAppNotificationServiceTest {
 
             // when & then
             ExceptionAssertions.assertThatExceptionOfType(
-                    () -> notificationService.markAsRead(notificationId),
+                    () -> notificationService.markAsRead(notificationId, 1L),
                     NotificationException.NOTIFICATION_NOT_FOUND
             );
         }


### PR DESCRIPTION
## 📌 한눈에 보기

| 구분 | 내용 |
| --- | --- |
| 공통 | API 공통 오류 응답과 예외 처리 추가 |
| 수강 | 수강 신청/취소 API 추가 |
| 알림 | 알림 요청, 상태 조회, 수동 재시도 API 추가 |
| 인앱 | 인앱 알림 목록 조회와 읽음 처리 API 추가 |
| 검증 | `./gradlew :notification-core:test :liveklass-api:compileJava --no-daemon` |

## 🔧 상세 변경

### 1. API 공통 기반 추가
- `ErrorResponse`, `GlobalExceptionHandler`를 추가해 공통 오류 응답 포맷과 예외 매핑 처리 추가
- `liveklass-api`에 validation, springdoc 의존성 연결

### 2. enrollment API 추가
- `EnrollmentApi`, `EnrollmentController`를 추가해 수강 신청/취소 엔드포인트 노출
- `EnrollmentRequest`, `EnrollmentCancelRequest`를 추가해 요청 DTO 정의

### 3. notification API 추가
- `NotificationApi`, `NotificationController`를 추가해 알림 요청, 상태 조회, 수동 재시도 엔드포인트 노출
- `NotificationSendRequest`, `NotificationStatusResponse`를 추가해 요청/응답 DTO 정의
- `OutboxService.manualRetry()`를 추가해 DEAD_LETTER 수동 재시도 처리 연결

### 4. in-app notification API 추가
- `InAppNotificationApi`, `InAppNotificationController`를 추가해 인앱 알림 목록 조회와 읽음 처리 엔드포인트 노출
- `InAppNotificationResponse`를 추가해 인앱 알림 응답 모델 정의
- `InAppNotificationService.markAsRead(notificationId, userId)`로 사용자 검증 기반 읽음 처리 연결

## 🧪 검증
- `./gradlew :notification-core:test :liveklass-api:compileJava --no-daemon`

## ✅ 체크리스트
- [x] 공통 예외 응답 추가
- [x] enrollment API 추가
- [x] notification API 추가
- [x] in-app notification API 추가
